### PR TITLE
A python converter for custom features to my proto format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,16 @@ For more details about the parameters, please use `python run_matching.py --help
 For more details about the underlying method and the interpretation of the results, please have a look at [paper](http://www.ipb.uni-bonn.de/pdfs/vysotska16ral-icra.pdf).
 Here is a sketch of what roughly is happening for those who don't like to read much ![](doc/cost_matrix_view.png)
 
+### Ok.. I don't know how to create protobufs, but I have my features as numpy matrix
+Perfect. Here is a python script that will convert your NxD matrix of features to the needed protobufs.
+``` bash
+python convert_numpy_features_to_protos.py \
+    --filename <your_features>.txt \
+    --feature_type NetVLAD \
+    --output_folder <folder_name> \
+    --output_file_prefix <fancy_feature_name>
+```
+
 ## Parent project
 
 This repository is a continuation of my previous works [vpr_relocalization](https://github.com/PRBonn/vpr_relocalization) and [online_place_recognition](https://github.com/PRBonn/online_place_recognition).

--- a/src/python/convert_numpy_features_to_protos.py
+++ b/src/python/convert_numpy_features_to_protos.py
@@ -20,7 +20,7 @@ def convert_to_protos(features, feature_type):
                                             localization_protos.proto file.
     """
     protos = []
-    assert len(features.shape) == 2
+    assert len(features.shape) == 2, "Expected a NxD dimensional matrix."
     for feature in features:
         feature_proto = loc_protos.Feature()
         feature_proto.size = feature.shape[0]
@@ -37,7 +37,9 @@ def save_protos_to_files(folder, protos, prefix):
         folder.mkdir()
     for idx, proto in enumerate(protos):
         feature_idx = "{0:07d}".format(idx)
-        proto_file = prefix + "_" + feature_idx + "." + proto.type + ".Feature.pb"
+        proto_file = "{prefix}_{feature_idx}.{proto_type}.Feature.pb".format(
+            prefix=prefix, feature_idx=feature_idx, proto_type=proto.type
+        )
         protos_io.write_feature(folder / proto_file, proto)
         print("Feature", idx, "was written to ", folder / proto_file)
     return

--- a/src/python/convert_numpy_features_to_protos.py
+++ b/src/python/convert_numpy_features_to_protos.py
@@ -1,0 +1,84 @@
+import numpy as np
+from pathlib import Path
+import argparse
+import protos_io
+
+import protos.localization_protos_pb2 as loc_protos
+
+
+def convert_to_protos(features, feature_type):
+    """Converts the numpy nd array to the features protos.
+
+    Args:
+        features (numpy.ndarray): feature vectors to be converted.
+                                Expected size NxD, where N is
+                                number of features and D is number
+                                of dimensions.
+    Returns:
+        [image_sequence_localizer.Feature]: list of feature protos.
+                                            For details check
+                                            localization_protos.proto file.
+    """
+    protos = []
+    assert len(features.shape) == 2
+    for feature in features:
+        feature_proto = loc_protos.Feature()
+        feature_proto.size = feature.shape[0]
+        feature_proto.type = feature_type
+        feature_proto.values.extend(feature)
+        protos.append(feature_proto)
+    return protos
+
+
+def save_protos_to_files(folder, protos, prefix):
+    if folder.exists():
+        print("WARNING: the folder exists. Potentially overwritting the files.")
+    else:
+        folder.mkdir()
+    for idx, proto in enumerate(protos):
+        feature_idx = "{0:07d}".format(idx)
+        proto_file = prefix + "_" + feature_idx + "." + proto.type + ".Feature.pb"
+        protos_io.write_feature(folder / proto_file, proto)
+        print("Feature", idx, "was written to ", folder / proto_file)
+    return
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--filename",
+        required=True,
+        type=Path,
+        help="Path to file that contains features in .txt format. "
+        "Expected format is NxD, where N is number of features and D is number of dimensions.",
+    )
+    parser.add_argument(
+        "--feature_type",
+        required=True,
+        type=str,
+        help="Type of the features, e.g. NetVLAD.",
+    )
+    parser.add_argument(
+        "--output_folder", required=True, type=Path, help="Path to db directory."
+    )
+    parser.add_argument(
+        "--output_file_prefix",
+        required=False,
+        type=str,
+        default="feature",
+        help="Prefix for every feature file that will be generated.",
+    )
+
+    args = parser.parse_args()
+    print("== Converting numpy matrix of features to protos ==")
+    try:
+        features = np.loadtxt(args.filename)
+    except:
+        print("ERROR: Could not read features from", args.filename)
+        return
+    protos = convert_to_protos(features, args.feature_type)
+    save_protos_to_files(args.output_folder, protos, args.output_file_prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/convert_numpy_features_to_protos_test.py
+++ b/src/python/convert_numpy_features_to_protos_test.py
@@ -1,0 +1,38 @@
+import pytest
+import numpy as np
+from pathlib import Path
+
+import convert_numpy_features_to_protos as converter
+
+
+def test_convert_to_protos():
+    features = np.array([[1, 2, 3], [4, 5, 6]])
+    feature_type = "Test"
+
+    protos = converter.convert_to_protos(features, feature_type)
+    np.testing.assert_equal(protos[0].values, features[0, :])
+    np.testing.assert_equal(protos[1].values, features[1, :])
+
+    assert protos[0].type == feature_type
+    assert protos[1].type == feature_type
+
+    assert protos[0].size == 3
+    assert protos[1].size == 3
+
+
+def test_convert_to_proto_not_valid():
+    features = np.zeros((2, 3, 4))
+    with pytest.raises(AssertionError):
+        protos = converter.convert_to_protos(features, "Test")
+
+
+def test_save_protos_to_files(tmp_path):
+    features = np.array([[1, 2, 3], [4, 5, 6]])
+    feature_type = "Test"
+    protos = converter.convert_to_protos(features, feature_type)
+    output_folder = tmp_path / Path("result")
+    converter.save_protos_to_files(output_folder, protos, "feature")
+
+    assert (output_folder / "feature_0000000.Test.Feature.pb").exists()
+    assert (output_folder / "feature_0000001.Test.Feature.pb").exists()
+    assert len(list(output_folder.glob("*.pb"))) == 2

--- a/src/python/protos_io.py
+++ b/src/python/protos_io.py
@@ -11,6 +11,12 @@ def read_feature(feature_filename):
     return np.array(feature_proto.values)
 
 
+def write_feature(filename, proto):
+    f = open(filename, "wb")
+    f.write(proto.SerializeToString())
+    f.close()
+
+
 def write_cost_matrix(cost_matrix, cost_matrix_file):
 
     cost_matrix_proto = loc_protos.CostMatrix()

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -2,5 +2,5 @@ numpy==1.23.3
 matplotlib==3.6.0
 protobuf==3.20.0
 opencv-python==4.6.0.66
-PyYAML==7
+PyYAML==6.0
 pytest==7.2.0

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -2,4 +2,5 @@ numpy==1.23.3
 matplotlib==3.6.0
 protobuf==3.20.0
 opencv-python==4.6.0.66
-PyYAML==6.0
+PyYAML==7
+pytest==7.2.0


### PR DESCRIPTION
**Problem**: No one is going to spend time to write the converter for their features to my custom proto format just to test if my code works :smile: 
**Solution**: This PR adds a python converter from numpy array to protos. It also adds a script that directly saves proto files to a folder. Then the full project can be run smoothly.

 I assume that people have their features as numpy array of size NxD where N is the number of features and D the dimensionality.

* If the features could be stored as a matrix in .txt format, then `convert_numpy_features_to_proto.py` can read this file (as long as np.loadtxt can read it :smile:) and produce the proto files.
* If people don't want to bother storing their features to a file, just get `convert_to_protos` function from the script.