### PR TITLE
Separate cost matrix

### DIFF
--- a/src/apps/cost_matrix_based_matching/CMakeLists.txt
+++ b/src/apps/cost_matrix_based_matching/CMakeLists.txt
@@ -12,3 +12,15 @@ target_link_libraries( cost_matrix_based_matching_lsh
     ${OpenCV_LIBS}
    
 )
+
+add_executable(cost_matrix_no_hashing cost_matrix_no_hashing.cpp)
+target_link_libraries(cost_matrix_no_hashing
+    glog::glog
+    online_localizer
+    cost_matrix_database
+    successor_manager
+    config_parser
+    default_relocalizer
+    ${OpenCV_LIBS}
+   
+)

--- a/src/apps/cost_matrix_based_matching/CMakeLists.txt
+++ b/src/apps/cost_matrix_based_matching/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenCV REQUIRED)
 
-add_executable(cost_matrix_based_matching_lsh cost_matrix_based_matching_lsh.cpp)
-target_link_libraries( cost_matrix_based_matching_lsh
+add_executable(online_localizer_lsh online_localizer_lsh.cpp)
+target_link_libraries(online_localizer_lsh
     glog::glog
     online_localizer
     cost_matrix_database
@@ -21,6 +21,5 @@ target_link_libraries(cost_matrix_no_hashing
     successor_manager
     config_parser
     default_relocalizer
-    ${OpenCV_LIBS}
-   
+    ${OpenCV_LIBS} 
 )

--- a/src/apps/cost_matrix_based_matching/cost_matrix_no_hashing.cpp
+++ b/src/apps/cost_matrix_based_matching/cost_matrix_no_hashing.cpp
@@ -1,10 +1,10 @@
+/* By O. Vysotska in 2023 */
 
 #include "database/cost_matrix_database.h"
 #include "database/idatabase.h"
 #include "online_localizer/online_localizer.h"
-#include "successor_manager/successor_manager.h"
-
 #include "relocalizers/default_relocalizer.h"
+#include "successor_manager/successor_manager.h"
 #include "tools/config_parser/config_parser.h"
 #include <glog/logging.h>
 
@@ -15,9 +15,9 @@ int main(int argc, char *argv[]) {
       << "===== Online place recognition cost matrix based NO HASHING ====\n";
 
   if (argc < 2) {
-    printf("[ERROR] Not enough input parameters.\n");
-    printf("Proper usage: ./cost_matrix_based_matching_no_hashing "
-           "config_file.yaml\n");
+    LOG(ERROR) << "Not enough input parameters.";
+    LOG(INFO) << "Proper usage: ./cost_matrix_based_matching_no_hashing "
+                 "config_file.yaml";
     exit(0);
   }
 
@@ -26,22 +26,19 @@ int main(int argc, char *argv[]) {
   parser.parseYaml(config_file);
   parser.print();
 
-  auto database = std::make_unique<CostMatrixDatabase>(
-      /*costMatrixFile=*/parser.costMatrix);
+  const auto database = std::make_unique<CostMatrixDatabase>(parser.costMatrix);
 
-  // initialize Relocalizer.
-  auto relocalizer =
+  const auto relocalizer =
       std::make_unique<DefaultRelocalizer>(parser.fanOut, database->refSize());
 
-  std::unique_ptr<SuccessorManager> successorManager =
-      std::make_unique<SuccessorManager>(database.get(), relocalizer.get(),
-                                         parser.fanOut);
+  const auto successorManager = std::make_unique<SuccessorManager>(
+      database.get(), relocalizer.get(), parser.fanOut);
   online_localizer::OnlineLocalizer localizer{
       successorManager.get(), parser.expansionRate, parser.nonMatchCost};
   const online_localizer::Matches imageMatches =
       localizer.findMatchesTill(parser.querySize);
   online_localizer::storeMatchesAsProto(imageMatches, parser.matchingResult);
 
-  printf("Done.\n");
+  LOG(INFO) << "Done.";
   return 0;
 }

--- a/src/apps/cost_matrix_based_matching/cost_matrix_no_hashing.cpp
+++ b/src/apps/cost_matrix_based_matching/cost_matrix_no_hashing.cpp
@@ -1,0 +1,47 @@
+
+#include "database/cost_matrix_database.h"
+#include "database/idatabase.h"
+#include "online_localizer/online_localizer.h"
+#include "successor_manager/successor_manager.h"
+
+#include "relocalizers/default_relocalizer.h"
+#include "tools/config_parser/config_parser.h"
+#include <glog/logging.h>
+
+int main(int argc, char *argv[]) {
+  google::InitGoogleLogging(argv[0]);
+  FLAGS_logtostderr = 1;
+  LOG(INFO)
+      << "===== Online place recognition cost matrix based NO HASHING ====\n";
+
+  if (argc < 2) {
+    printf("[ERROR] Not enough input parameters.\n");
+    printf("Proper usage: ./cost_matrix_based_matching_no_hashing "
+           "config_file.yaml\n");
+    exit(0);
+  }
+
+  std::string config_file = argv[1];
+  ConfigParser parser;
+  parser.parseYaml(config_file);
+  parser.print();
+
+  auto database = std::make_unique<CostMatrixDatabase>(
+      /*costMatrixFile=*/parser.costMatrix);
+
+  // initialize Relocalizer.
+  auto relocalizer =
+      std::make_unique<DefaultRelocalizer>(parser.fanOut, database->refSize());
+
+  std::unique_ptr<SuccessorManager> successorManager =
+      std::make_unique<SuccessorManager>(database.get(), relocalizer.get(),
+                                         parser.fanOut);
+  online_localizer::OnlineLocalizer localizer{
+      successorManager.get(), parser.expansionRate, parser.nonMatchCost};
+  const online_localizer::Matches imageMatches =
+      localizer.findMatchesTill(parser.querySize);
+  online_localizer::storeMatchesAsProto(imageMatches, parser.matchingResult);
+
+  printf("Done.\n");
+  return 0;
+}

--- a/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
+++ b/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
@@ -80,7 +80,6 @@ int main(int argc, char *argv[]) {
       /*bufferSize=*/parser.bufferSize,
       /*costMatrixFile=*/parser.costMatrix);
 
-  // initialize Relocalizer.
   auto relocalizer = std::make_unique<loc::relocalizers::LshCvHashing>(
       /*onlineDatabase=*/database.get(),
       /*tableNum=*/1,

--- a/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
+++ b/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
@@ -25,7 +25,6 @@
 #include <memory>
 #include <string>
 
-#include "database/cost_matrix_database.h"
 #include "database/idatabase.h"
 #include "database/list_dir.h"
 #include "database/online_database.h"
@@ -70,12 +69,11 @@ int main(int argc, char *argv[]) {
   parser.parseYaml(config_file);
   parser.print();
 
-  std::unique_ptr<OnlineDatabase> database =
-      std::make_unique<CostMatrixDatabase>(
-          /*costMatrixFile=*/parser.costMatrix,
-          /*queryFeaturesDir=*/parser.path2qu,
-          /*refFeaturesDir=*/parser.path2ref, /*type=*/FeatureType::Cnn_Feature,
-          /*bufferSize=*/parser.bufferSize);
+  std::unique_ptr<OnlineDatabase> database = std::make_unique<OnlineDatabase>(
+      /*queryFeaturesDir=*/parser.path2qu,
+      /*refFeaturesDir=*/parser.path2ref, /*type=*/FeatureType::Cnn_Feature,
+      /*bufferSize=*/parser.bufferSize,
+      /*costMatrixFile=*/parser.costMatrix);
 
   // initialize Relocalizer.
   auto relocalizer = std::make_unique<LshCvHashing>(

--- a/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
+++ b/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
@@ -21,10 +21,6 @@
 ** SOFTWARE.
 **/
 
-#include <iostream>
-#include <memory>
-#include <string>
-
 #include "database/idatabase.h"
 #include "database/list_dir.h"
 #include "database/online_database.h"
@@ -38,14 +34,22 @@
 
 #include <glog/logging.h>
 
-std::vector<std::unique_ptr<iFeature>>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace loc = localization;
+
+std::vector<std::unique_ptr<loc::features::iFeature>>
 loadFeatures(const std::string &path2folder) {
   LOG(INFO) << "Loading the features to hash with LSH.";
-  std::vector<std::string> featureNames = listProtoDir(path2folder, ".Feature");
-  std::vector<std::unique_ptr<iFeature>> features;
+  std::vector<std::string> featureNames =
+      loc::database::listProtoDir(path2folder, ".Feature");
+  std::vector<std::unique_ptr<loc::features::iFeature>> features;
 
   for (size_t i = 0; i < featureNames.size(); ++i) {
-    features.emplace_back(std::make_unique<CnnFeature>(featureNames[i]));
+    features.emplace_back(
+        std::make_unique<loc::features::CnnFeature>(featureNames[i]));
     fprintf(stderr, ".");
   }
   fprintf(stderr, "\n");
@@ -69,28 +73,30 @@ int main(int argc, char *argv[]) {
   parser.parseYaml(config_file);
   parser.print();
 
-  std::unique_ptr<OnlineDatabase> database = std::make_unique<OnlineDatabase>(
+  const auto database = std::make_unique<loc::database::OnlineDatabase>(
       /*queryFeaturesDir=*/parser.path2qu,
-      /*refFeaturesDir=*/parser.path2ref, /*type=*/FeatureType::Cnn_Feature,
+      /*refFeaturesDir=*/parser.path2ref,
+      /*type=*/loc::features::FeatureType::Cnn_Feature,
       /*bufferSize=*/parser.bufferSize,
       /*costMatrixFile=*/parser.costMatrix);
 
   // initialize Relocalizer.
-  auto relocalizer = std::make_unique<LshCvHashing>(
+  auto relocalizer = std::make_unique<loc::relocalizers::LshCvHashing>(
       /*onlineDatabase=*/database.get(),
       /*tableNum=*/1,
       /*keySize=*/12,
       /*multiProbeLevel=*/2);
   relocalizer->train(loadFeatures(parser.path2ref));
 
-  std::unique_ptr<SuccessorManager> successorManager =
-      std::make_unique<SuccessorManager>(database.get(), relocalizer.get(),
-                                         parser.fanOut);
-  online_localizer::OnlineLocalizer localizer{
+  auto successorManager =
+      std::make_unique<loc::successor_manager::SuccessorManager>(
+          database.get(), relocalizer.get(), parser.fanOut);
+  loc::online_localizer::OnlineLocalizer localizer{
       successorManager.get(), parser.expansionRate, parser.nonMatchCost};
-  const online_localizer::Matches imageMatches =
+  const loc::online_localizer::Matches imageMatches =
       localizer.findMatchesTill(parser.querySize);
-  online_localizer::storeMatchesAsProto(imageMatches, parser.matchingResult);
+  loc::online_localizer::storeMatchesAsProto(imageMatches,
+                                             parser.matchingResult);
 
   printf("Done.\n");
   return 0;

--- a/src/localization/database/CMakeLists.txt
+++ b/src/localization/database/CMakeLists.txt
@@ -1,36 +1,34 @@
 add_library(list_dir list_dir.cpp)
 target_link_libraries(list_dir 	
-	cxx_flags
-	glog::glog
+    cxx_flags
+    glog::glog
 )
 
-	
 add_library(cost_matrix cost_matrix.cpp)
 target_link_libraries(cost_matrix
-	feature_factory
-	list_dir
-	protos
-	glog::glog
+    feature_factory
+    list_dir
+    protos
+    glog::glog
 )
 
 add_library(online_database online_database.cpp)
 target_link_libraries(online_database
-	timer 
+    timer 
     list_dir
-	feature_buffer
+    feature_buffer
     feature_factory
-	glog::glog
-	cost_matrix
+    glog::glog
+    cost_matrix
 )
-
 
 add_library(cost_matrix_database cost_matrix_database.cpp)
 target_link_libraries(cost_matrix_database
-	timer 
+    timer 
     list_dir
-	feature_buffer
+    feature_buffer
     feature_factory
-	glog::glog
-	cost_matrix
+    glog::glog
+    cost_matrix
 )
 

--- a/src/localization/database/CMakeLists.txt
+++ b/src/localization/database/CMakeLists.txt
@@ -13,9 +13,8 @@ target_link_libraries(online_database
 	glog::glog
 )
 	
-add_library(cost_matrix_database cost_matrix_database.cpp)
-target_link_libraries(cost_matrix_database 
-	online_database
+add_library(cost_matrix cost_matrix.cpp)
+target_link_libraries(cost_matrix 
 	protos
 	glog::glog
 )

--- a/src/localization/database/CMakeLists.txt
+++ b/src/localization/database/CMakeLists.txt
@@ -4,6 +4,15 @@ target_link_libraries(list_dir
 	glog::glog
 )
 
+	
+add_library(cost_matrix cost_matrix.cpp)
+target_link_libraries(cost_matrix
+	feature_factory
+	list_dir
+	protos
+	glog::glog
+)
+
 add_library(online_database online_database.cpp)
 target_link_libraries(online_database
 	timer 
@@ -11,10 +20,17 @@ target_link_libraries(online_database
 	feature_buffer
     feature_factory
 	glog::glog
+	cost_matrix
 )
-	
-add_library(cost_matrix cost_matrix.cpp)
-target_link_libraries(cost_matrix 
-	protos
+
+
+add_library(cost_matrix_database cost_matrix_database.cpp)
+target_link_libraries(cost_matrix_database
+	timer 
+    list_dir
+	feature_buffer
+    feature_factory
 	glog::glog
+	cost_matrix
 )
+

--- a/src/localization/database/cost_matrix.cpp
+++ b/src/localization/database/cost_matrix.cpp
@@ -1,0 +1,46 @@
+#include "cost_matrix.h"
+#include <fstream>
+
+#include "localization_protos.pb.h"
+
+#include <glog/logging.h>
+
+void CostMatrix::loadFromTxt(const std::string &filename, int rows, int cols) {
+  std::ifstream in(filename);
+  LOG_IF(FATAL, !in) << "The file cannot be opened " << filename;
+
+  LOG(INFO) << "The matrix has " << rows << " rows and " << cols << "cols";
+  for (int r = 0; r < rows; ++r) {
+    std::vector<double> row(cols);
+    for (int c = 0; c < cols; ++c) {
+      float value;
+      in >> value;
+      row[c] = value;
+    }
+    costs_.push_back(row);
+  }
+  LOG(INFO) << "Matrix was read";
+  in.close();
+}
+
+void CostMatrix::loadFromProto(const std::string &filename) {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  image_sequence_localizer::CostMatrix cost_matrix_proto;
+  std::fstream input(filename, std::ios::in | std::ios::binary);
+
+  if (!cost_matrix_proto.ParseFromIstream(&input)) {
+    LOG(FATAL) << "Failed to parse cost_matrix file: " << filename;
+  }
+  std::vector<double> row;
+  for (int idx = 0; idx < cost_matrix_proto.values_size(); ++idx) {
+    row.push_back(cost_matrix_proto.values(idx));
+    if (row.size() == cost_matrix_proto.cols()) {
+      costs_.push_back(row);
+      row.clear();
+    }
+  }
+  cols_ = cost_matrix_proto.cols();
+  rows_ = cost_matrix_proto.rows();
+  LOG(INFO) << "Read cost matrix with " << rows_ << " rows and " << cols_
+            << " cols.";
+}

--- a/src/localization/database/cost_matrix.cpp
+++ b/src/localization/database/cost_matrix.cpp
@@ -11,6 +11,10 @@
 
 namespace localization::database {
 
+namespace {
+constexpr auto kEpsilon = 1e-09;
+} // namespace
+
 CostMatrix::CostMatrix(const std::string &costMatrixFile) {
   CHECK(!costMatrixFile.empty()) << "Cost matrix file is not set";
   loadFromProto(costMatrixFile);
@@ -19,10 +23,9 @@ CostMatrix::CostMatrix(const std::string &costMatrixFile) {
 CostMatrix::CostMatrix(const std::string &queryFeaturesDir,
                        const std::string &refFeaturesDir,
                        const features::FeatureType &type) {
-
-  std::vector<std::string> queryFeatureFiles =
+  const std::vector<std::string> queryFeatureFiles =
       listProtoDir(queryFeaturesDir, ".Feature");
-  std::vector<std::string> refFeaturesFiles =
+  const std::vector<std::string> refFeaturesFiles =
       listProtoDir(refFeaturesDir, ".Feature");
 
   costs_.reserve(queryFeatureFiles.size());
@@ -52,8 +55,7 @@ void CostMatrix::loadFromTxt(const std::string &filename, int rows, int cols) {
     std::vector<double> row(cols);
     for (int c = 0; c < cols; ++c) {
       float value;
-      in >> value;
-      row[c] = value;
+      in >> row[c];
     }
     costs_.push_back(row);
   }
@@ -71,7 +73,7 @@ double CostMatrix::at(int row, int col) const {
 
 double CostMatrix::getInverseCost(int row, int col) const {
   const double value = this->at(row, col);
-  if (abs(value) < 1e-09) {
+  if (std::abs(value) < kEpsilon) {
     return std::numeric_limits<double>::max();
   }
   return 1. / value;

--- a/src/localization/database/cost_matrix.cpp
+++ b/src/localization/database/cost_matrix.cpp
@@ -23,13 +23,16 @@ CostMatrix::CostMatrix(const std::string &costMatrixFile) {
 CostMatrix::CostMatrix(const std::string &queryFeaturesDir,
                        const std::string &refFeaturesDir,
                        const features::FeatureType &type) {
-  const std::vector<std::string> queryFeatureFiles =
+  const std::vector<std::string> queryFeaturesFiles =
       listProtoDir(queryFeaturesDir, ".Feature");
   const std::vector<std::string> refFeaturesFiles =
       listProtoDir(refFeaturesDir, ".Feature");
 
-  costs_.reserve(queryFeatureFiles.size());
-  for (const auto &queryFile : queryFeatureFiles) {
+  std::cerr << "Query features" << queryFeaturesFiles.size() << std::endl;
+  std::cerr << "ref features" << refFeaturesFiles.size() << std::endl;
+
+  costs_.reserve(queryFeaturesFiles.size());
+  for (const auto &queryFile : queryFeaturesFiles) {
     auto queryFeature = createFeature(type, queryFile);
     std::vector<double> row;
     row.reserve(refFeaturesFiles.size());
@@ -39,7 +42,12 @@ CostMatrix::CostMatrix(const std::string &queryFeaturesDir,
     }
     costs_.push_back(row);
   }
+  rows_ = costs_.size();
+  if (costs_.size() > 0) {
+    cols_ = costs_[0].size();
+  }
 }
+
 CostMatrix::CostMatrix(const Matrix &costs) {
   costs_ = costs;
   rows_ = costs.size();

--- a/src/localization/database/cost_matrix.cpp
+++ b/src/localization/database/cost_matrix.cpp
@@ -1,13 +1,15 @@
 /* By O. Vysotska in 2023 */
 
 #include "cost_matrix.h"
-#include <fstream>
-
 #include "database/list_dir.h"
 #include "features/feature_factory.h"
 #include "localization_protos.pb.h"
 
 #include <glog/logging.h>
+
+#include <fstream>
+
+namespace localization::database {
 
 CostMatrix::CostMatrix(const std::string &costMatrixFile) {
   CHECK(!costMatrixFile.empty()) << "Cost matrix file is not set";
@@ -16,7 +18,7 @@ CostMatrix::CostMatrix(const std::string &costMatrixFile) {
 
 CostMatrix::CostMatrix(const std::string &queryFeaturesDir,
                        const std::string &refFeaturesDir,
-                       const FeatureType &type) {
+                       const features::FeatureType &type) {
 
   std::vector<std::string> queryFeatureFiles =
       listProtoDir(queryFeaturesDir, ".Feature");
@@ -96,3 +98,4 @@ void CostMatrix::loadFromProto(const std::string &filename) {
   LOG(INFO) << "Read cost matrix with " << rows_ << " rows and " << cols_
             << " cols.";
 }
+} // namespace localization::database

--- a/src/localization/database/cost_matrix.cpp
+++ b/src/localization/database/cost_matrix.cpp
@@ -1,3 +1,5 @@
+/* By O. Vysotska in 2023 */
+
 #include "cost_matrix.h"
 #include <fstream>
 
@@ -11,6 +13,7 @@ CostMatrix::CostMatrix(const std::string &costMatrixFile) {
   CHECK(!costMatrixFile.empty()) << "Cost matrix file is not set";
   loadFromProto(costMatrixFile);
 }
+
 CostMatrix::CostMatrix(const std::string &queryFeaturesDir,
                        const std::string &refFeaturesDir,
                        const FeatureType &type) {
@@ -23,7 +26,8 @@ CostMatrix::CostMatrix(const std::string &queryFeaturesDir,
   costs_.reserve(queryFeatureFiles.size());
   for (const auto &queryFile : queryFeatureFiles) {
     auto queryFeature = createFeature(type, queryFile);
-    std::vector<double> row(refFeaturesFiles.size());
+    std::vector<double> row;
+    row.reserve(refFeaturesFiles.size());
     for (const auto &refFile : refFeaturesFiles) {
       const auto refFeature = createFeature(type, refFile);
       row.push_back(queryFeature->computeSimilarityScore(*refFeature));

--- a/src/localization/database/cost_matrix.h
+++ b/src/localization/database/cost_matrix.h
@@ -1,9 +1,10 @@
-#ifndef SRC_DATABASE_COST_MATRIX_DATABASE_H_
-#define SRC_DATABASE_COST_MATRIX_DATABASE_H_
+#ifndef SRC_DATABASE_COST_MATRIX_H_
+#define SRC_DATABASE_COST_MATRIX_H_
 
-#include "database/online_database.h"
+#include "features/feature_factory.h"
 
 #include <string>
+#include <vector>
 
 using Matrix = std::vector<std::vector<double>>;
 
@@ -30,9 +31,15 @@ public:
   const Matrix &getCosts() const { return costs_; }
 
   double at(int row, int col) const;
+  // Computes 1/value.
+  double getInverseCost(int row, int col) const;
+  int rows() const { return rows_; }
+  int cols() const { return cols_; }
 
 private:
   Matrix costs_;
   int rows_ = 0;
   int cols_ = 0;
 };
+
+#endif // SRC_DATABASE_COST_MATRIX_H_

--- a/src/localization/database/cost_matrix.h
+++ b/src/localization/database/cost_matrix.h
@@ -1,0 +1,38 @@
+#ifndef SRC_DATABASE_COST_MATRIX_DATABASE_H_
+#define SRC_DATABASE_COST_MATRIX_DATABASE_H_
+
+#include "database/online_database.h"
+
+#include <string>
+
+using Matrix = std::vector<std::vector<double>>;
+
+/**
+ * @brief  Stores costs as matrix.
+ */
+class CostMatrix {
+public:
+  CostMatrix(const std::string &costMatrixFile);
+  CostMatrix(const std::string &queryFeaturesDir,
+             const std::string &refFeaturesDir, const FeatureType &type);
+  CostMatrix(const Matrix &costs);
+
+  /**
+   * @brief      Loads from txt. Expects specific format: Pure matrix values.
+   *
+   * @param[in]  filename  The filename
+   * @param[in]  rows      The rows
+   * @param[in]  cols      The cols
+   */
+  void loadFromTxt(const std::string &filename, int rows, int cols);
+
+  void loadFromProto(const std::string &filename);
+  const Matrix &getCosts() const { return costs_; }
+
+  double at(int row, int col) const;
+
+private:
+  Matrix costs_;
+  int rows_ = 0;
+  int cols_ = 0;
+};

--- a/src/localization/database/cost_matrix.h
+++ b/src/localization/database/cost_matrix.h
@@ -8,25 +8,17 @@
 #include <string>
 #include <vector>
 
-using Matrix = std::vector<std::vector<double>>;
-
-/**
- * @brief  Stores costs as matrix.
- */
+namespace localization::database {
 class CostMatrix {
 public:
+  using Matrix = std::vector<std::vector<double>>;
+
   CostMatrix(const std::string &costMatrixFile);
   CostMatrix(const std::string &queryFeaturesDir,
-             const std::string &refFeaturesDir, const FeatureType &type);
+             const std::string &refFeaturesDir,
+             const features::FeatureType &type);
   CostMatrix(const Matrix &costs);
 
-  /**
-   * @brief      Loads from txt. Expects specific format: Pure matrix values.
-   *
-   * @param[in]  filename  The filename
-   * @param[in]  rows      The rows
-   * @param[in]  cols      The cols
-   */
   void loadFromTxt(const std::string &filename, int rows, int cols);
 
   void loadFromProto(const std::string &filename);
@@ -43,5 +35,6 @@ private:
   int rows_ = 0;
   int cols_ = 0;
 };
+} // namespace localization::database
 
 #endif // SRC_DATABASE_COST_MATRIX_H_

--- a/src/localization/database/cost_matrix.h
+++ b/src/localization/database/cost_matrix.h
@@ -13,11 +13,11 @@ class CostMatrix {
 public:
   using Matrix = std::vector<std::vector<double>>;
 
-  CostMatrix(const std::string &costMatrixFile);
+  explicit CostMatrix(const std::string &costMatrixFile);
   CostMatrix(const std::string &queryFeaturesDir,
              const std::string &refFeaturesDir,
              const features::FeatureType &type);
-  CostMatrix(const Matrix &costs);
+  explicit CostMatrix(const Matrix &costs);
 
   void loadFromTxt(const std::string &filename, int rows, int cols);
 

--- a/src/localization/database/cost_matrix.h
+++ b/src/localization/database/cost_matrix.h
@@ -1,3 +1,5 @@
+/* By O. Vysotska in 2023 */
+
 #ifndef SRC_DATABASE_COST_MATRIX_H_
 #define SRC_DATABASE_COST_MATRIX_H_
 

--- a/src/localization/database/cost_matrix_database.cpp
+++ b/src/localization/database/cost_matrix_database.cpp
@@ -30,6 +30,8 @@
 
 #include <glog/logging.h>
 
+namespace localization::database {
+
 CostMatrixDatabase::CostMatrixDatabase(const std::string &costMatrixFile) {
   costMatrix_ = std::make_unique<CostMatrix>(costMatrixFile);
 }
@@ -37,3 +39,5 @@ CostMatrixDatabase::CostMatrixDatabase(const std::string &costMatrixFile) {
 double CostMatrixDatabase::getCost(int quId, int refId) {
   return costMatrix_->getInverseCost(quId, refId);
 }
+
+} // namespace localization::database

--- a/src/localization/database/cost_matrix_database.cpp
+++ b/src/localization/database/cost_matrix_database.cpp
@@ -28,75 +28,12 @@
 #include <fstream>
 #include <limits>
 
-#include "database/online_database.h"
-#include "localization_protos.pb.h"
-
 #include <glog/logging.h>
 
-CostMatrixDatabase::CostMatrixDatabase(const std::string &costMatrixFile,
-                                       const std::string &queryFeaturesDir,
-                                       const std::string &refFeaturesDir,
-                                       const FeatureType &type, int bufferSize)
-    : OnlineDatabase{queryFeaturesDir, refFeaturesDir, type, bufferSize} {
-  loadFromProto(costMatrixFile);
-}
-
-void CostMatrixDatabase::loadFromTxt(const std::string &filename, int rows,
-                                     int cols) {
-  std::ifstream in(filename);
-  LOG_IF(FATAL, !in) << "The file cannot be opened " << filename;
-
-  LOG(INFO) << "The matrix has " << rows << " rows and " << cols << "cols";
-  for (int r = 0; r < rows; ++r) {
-    std::vector<double> row(cols);
-    for (int c = 0; c < cols; ++c) {
-      float value;
-      in >> value;
-      row[c] = value;
-    }
-    costs_.push_back(row);
-  }
-  LOG(INFO) << "Matrix was read";
-  in.close();
-}
-
-void CostMatrixDatabase::overrideCosts(const Matrix &costs, int rows,
-                                       int cols) {
-  rows_ = rows;
-  cols_ = cols;
-  costs_ = costs;
+CostMatrixDatabase::CostMatrixDatabase(const std::string &costMatrixFile) {
+  costMatrix_ = std::make_unique<CostMatrix>(costMatrixFile);
 }
 
 double CostMatrixDatabase::getCost(int quId, int refId) {
-  LOG_IF(FATAL, quId >= rows_ || quId < 0) << " Invalid query index " << quId;
-  LOG_IF(FATAL, refId >= cols_ || refId < 0)
-      << " Invalid reference index " << refId;
-
-  double value = costs_[quId][refId];
-  if (value < 1e-09) {
-    return std::numeric_limits<double>::max();
-  }
-  return 1. / value;
-}
-
-void CostMatrixDatabase::loadFromProto(const std::string &filename) {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-  image_sequence_localizer::CostMatrix cost_matrix_proto;
-  std::fstream input(filename, std::ios::in | std::ios::binary);
-
-  if (!cost_matrix_proto.ParseFromIstream(&input)) {
-    LOG(FATAL) << "Failed to parse cost_matrix file: " << filename;
-  }
-  std::vector<double> row;
-  for (int idx = 0; idx < cost_matrix_proto.values_size(); ++idx) {
-    row.push_back(cost_matrix_proto.values(idx));
-    if (row.size() == cost_matrix_proto.cols()) {
-      costs_.push_back(row);
-      row.clear();
-    }
-  }
-  cols_ = cost_matrix_proto.cols();
-  rows_ = cost_matrix_proto.rows();
-  LOG(INFO) << "Read cost matrix with " << rows_ << " rows and " << cols_
-            << " cols.";
+  return costMatrix_->getInverseCost(quId, refId);
 }

--- a/src/localization/database/cost_matrix_database.cpp
+++ b/src/localization/database/cost_matrix_database.cpp
@@ -24,6 +24,7 @@
 /* Updated by O. Vysotska in 2022 */
 
 #include "database/cost_matrix_database.h"
+#include "database/cost_matrix.h"
 
 #include <fstream>
 #include <limits>
@@ -32,12 +33,11 @@
 
 namespace localization::database {
 
-CostMatrixDatabase::CostMatrixDatabase(const std::string &costMatrixFile) {
-  costMatrix_ = std::make_unique<CostMatrix>(costMatrixFile);
-}
+CostMatrixDatabase::CostMatrixDatabase(const std::string &costMatrixFile)
+    : costMatrix_(CostMatrix(costMatrixFile)) {}
 
 double CostMatrixDatabase::getCost(int quId, int refId) {
-  return costMatrix_->getInverseCost(quId, refId);
+  return costMatrix_.getInverseCost(quId, refId);
 }
 
 } // namespace localization::database

--- a/src/localization/database/cost_matrix_database.h
+++ b/src/localization/database/cost_matrix_database.h
@@ -26,28 +26,24 @@
 #ifndef SRC_DATABASE_COST_MATRIX_DATABASE_H_
 #define SRC_DATABASE_COST_MATRIX_DATABASE_H_
 
-#include "database/online_database.h"
+#include "database/cost_matrix.h"
+#include "database/idatabase.h"
 
+#include <memory>
 #include <string>
-
-using Matrix = std::vector<std::vector<double>>;
 
 /**
  * @brief      Class for cost matrix database. Stores costs as matrix.
  */
-class CostMatrixDatabase : public OnlineDatabase {
+class CostMatrixDatabase : public iDatabase {
 public:
-  CostMatrixDatabase(const std::string &costMatrixFile,
-                     const std::string &queryFeaturesDir,
-                     const std::string &refFeaturesDir, const FeatureType &type,
-                     int bufferSize);
+  CostMatrixDatabase(const std::string &costMatrixFile);
 
-  int refSize() override { return cols_; }
-  /** gets the original cost and transforms it 1/cost **/
+  int refSize() override { return costMatrix_->cols(); }
   double getCost(int quId, int refId) override;
 
 private:
-  // CostMatrixDatabase
+  std::unique_ptr<CostMatrix> costMatrix_ = nullptr;
 };
 
 #endif // SRC_DATABASE_COST_MATRIX_DATABASE_H_

--- a/src/localization/database/cost_matrix_database.h
+++ b/src/localization/database/cost_matrix_database.h
@@ -32,9 +32,8 @@
 #include <memory>
 #include <string>
 
-/**
- * @brief      Class for cost matrix database. Stores costs as matrix.
- */
+namespace localization::database {
+
 class CostMatrixDatabase : public iDatabase {
 public:
   CostMatrixDatabase(const std::string &costMatrixFile);
@@ -45,5 +44,7 @@ public:
 private:
   std::unique_ptr<CostMatrix> costMatrix_ = nullptr;
 };
+
+} // namespace localization::database
 
 #endif // SRC_DATABASE_COST_MATRIX_DATABASE_H_

--- a/src/localization/database/cost_matrix_database.h
+++ b/src/localization/database/cost_matrix_database.h
@@ -46,24 +46,8 @@ public:
   /** gets the original cost and transforms it 1/cost **/
   double getCost(int quId, int refId) override;
 
-  /**
-   * @brief      Loads from txt. Expects specific format: Pure matrix values.
-   *
-   * @param[in]  filename  The filename
-   * @param[in]  rows      The rows
-   * @param[in]  cols      The cols
-   */
-  void loadFromTxt(const std::string &filename, int rows, int cols);
-
-  void loadFromProto(const std::string &filename);
-
-  void overrideCosts(const Matrix &costs, int rows, int cols);
-  const Matrix &getCosts() const { return costs_; }
-
 private:
-  Matrix costs_;
-  int rows_ = 0;
-  int cols_ = 0;
+  // CostMatrixDatabase
 };
 
 #endif // SRC_DATABASE_COST_MATRIX_DATABASE_H_

--- a/src/localization/database/cost_matrix_database.h
+++ b/src/localization/database/cost_matrix_database.h
@@ -36,13 +36,13 @@ namespace localization::database {
 
 class CostMatrixDatabase : public iDatabase {
 public:
-  CostMatrixDatabase(const std::string &costMatrixFile);
+  explicit CostMatrixDatabase(const std::string &costMatrixFile);
 
-  int refSize() override { return costMatrix_->cols(); }
+  int refSize() override { return costMatrix_.cols(); }
   double getCost(int quId, int refId) override;
 
 private:
-  std::unique_ptr<CostMatrix> costMatrix_ = nullptr;
+  CostMatrix costMatrix_;
 };
 
 } // namespace localization::database

--- a/src/localization/database/idatabase.h
+++ b/src/localization/database/idatabase.h
@@ -24,6 +24,8 @@
 #ifndef SRC_DATABASE_IDATABASE_H_
 #define SRC_DATABASE_IDATABASE_H_
 
+namespace localization::database {
+
 /**
  * @brief      Interface class for a database.
  */
@@ -48,5 +50,7 @@ public:
   iDatabase &operator=(iDatabase &&) = delete;
   virtual ~iDatabase() {}
 };
+
+} // namespace localization::database
 
 #endif // SRC_DATABASE_IDATABASE_H_

--- a/src/localization/database/list_dir.cpp
+++ b/src/localization/database/list_dir.cpp
@@ -30,6 +30,8 @@
 
 #include <glog/logging.h>
 
+namespace localization::database {
+
 namespace fs = std::filesystem;
 
 std::vector<std::string> listDir(const std::string &dir_name) {
@@ -80,3 +82,4 @@ std::vector<std::string> listProtoDir(const std::string &pathToDir,
   std::sort(proto_files.begin(), proto_files.end());
   return proto_files;
 }
+} // namespace localization::database

--- a/src/localization/database/list_dir.h
+++ b/src/localization/database/list_dir.h
@@ -27,9 +27,13 @@
 #include <string>
 #include <vector>
 
+namespace localization::database {
+
 std::vector<std::string> listDir(const std::string &dir_name);
 
 std::vector<std::string> listProtoDir(const std::string &pathToDir,
                                       const std::string &protoExtension);
+
+} // namespace localization::database
 
 #endif // SRC_DATABASE_LIST_DIR_H_

--- a/src/localization/database/online_database.cpp
+++ b/src/localization/database/online_database.cpp
@@ -60,7 +60,7 @@ OnlineDatabase::OnlineDatabase(const std::string &queryFeaturesDir,
   LOG_IF(FATAL, quFeaturesNames_.empty()) << "Query features are not set.";
   LOG_IF(FATAL, refFeaturesNames_.empty()) << "Reference features are not set.";
   if (!costMatrixFile.empty()) {
-    precomputedCosts_ = std::make_unique<CostMatrix>(costMatrixFile);
+    precomputedCosts_ = CostMatrix(costMatrixFile);
   }
 }
 

--- a/src/localization/database/online_database.cpp
+++ b/src/localization/database/online_database.cpp
@@ -35,10 +35,13 @@
 #include <memory>
 #include <string>
 
+namespace localization::database {
+
 namespace {
-const iFeature &addFeatureIfNeeded(FeatureBuffer &featureBuffer,
-                                   const std::vector<std::string> &featureNames,
-                                   FeatureType type, int featureId) {
+const features::iFeature &
+addFeatureIfNeeded(features::FeatureBuffer &featureBuffer,
+                   const std::vector<std::string> &featureNames,
+                   features::FeatureType type, int featureId) {
   if (featureBuffer.inBuffer(featureId)) {
     return featureBuffer.getFeature(featureId);
   }
@@ -50,13 +53,13 @@ const iFeature &addFeatureIfNeeded(FeatureBuffer &featureBuffer,
 
 OnlineDatabase::OnlineDatabase(const std::string &queryFeaturesDir,
                                const std::string &refFeaturesDir,
-                               FeatureType type, int bufferSize,
+                               features::FeatureType type, int bufferSize,
                                const std::string &costMatrixFile)
     : quFeaturesNames_{listProtoDir(queryFeaturesDir, ".Feature")},
       refFeaturesNames_{listProtoDir(refFeaturesDir, ".Feature")},
-      featureType_{type}, refBuffer_{std::make_unique<FeatureBuffer>(
+      featureType_{type}, refBuffer_{std::make_unique<features::FeatureBuffer>(
                               bufferSize)},
-      queryBuffer_{std::make_unique<FeatureBuffer>(bufferSize)} {
+      queryBuffer_{std::make_unique<features::FeatureBuffer>(bufferSize)} {
   LOG_IF(FATAL, quFeaturesNames_.empty()) << "Query features are not set.";
   LOG_IF(FATAL, refFeaturesNames_.empty()) << "Reference features are not set.";
   if (!costMatrixFile.empty()) {
@@ -95,7 +98,8 @@ double OnlineDatabase::getCost(int quId, int refId) {
   return cost;
 }
 
-const iFeature &OnlineDatabase::getQueryFeature(int quId) {
+const features::iFeature &OnlineDatabase::getQueryFeature(int quId) {
   return addFeatureIfNeeded(*queryBuffer_, quFeaturesNames_, featureType_,
                             quId);
 }
+} // namespace localization::database

--- a/src/localization/database/online_database.h
+++ b/src/localization/database/online_database.h
@@ -50,7 +50,7 @@ public:
 
   double computeMatchingCost(int quId, int refId);
 
-  const iFeature& getQueryFeature(int quId);
+  const iFeature &getQueryFeature(int quId);
 
 protected:
   std::vector<std::string> quFeaturesNames_;
@@ -62,6 +62,8 @@ private:
   std::unique_ptr<FeatureBuffer> refBuffer_{};
   std::unique_ptr<FeatureBuffer> queryBuffer_{};
   std::unordered_map<int, std::unordered_map<int, double>> costs_;
+
+  std::optional<CostMatrix> precomputedCosts;
 };
 
 #endif // SRC_DATABASE_ONLINE_DATABASE_H_

--- a/src/localization/database/online_database.h
+++ b/src/localization/database/online_database.h
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <vector>
 
+namespace localization::database {
 /**
  * @brief      Database for loading and matching features. Caches the computed
  * matching costs.
@@ -44,7 +45,7 @@
 class OnlineDatabase : public iDatabase {
 public:
   OnlineDatabase(const std::string &queryFeaturesDir,
-                 const std::string &refFeaturesDir, FeatureType type,
+                 const std::string &refFeaturesDir, features::FeatureType type,
                  int bufferSize, const std::string &costMatrixFile = "");
 
   inline int refSize() override { return refFeaturesNames_.size(); }
@@ -52,20 +53,21 @@ public:
 
   double computeMatchingCost(int quId, int refId);
 
-  const iFeature &getQueryFeature(int quId);
+  const features::iFeature &getQueryFeature(int quId);
 
 protected:
   std::vector<std::string> quFeaturesNames_;
   std::vector<std::string> refFeaturesNames_;
   // TODO(olga): Maybe temporary here.
-  FeatureType featureType_{};
+  features::FeatureType featureType_{};
 
 private:
-  std::unique_ptr<FeatureBuffer> refBuffer_{};
-  std::unique_ptr<FeatureBuffer> queryBuffer_{};
+  std::unique_ptr<features::FeatureBuffer> refBuffer_{};
+  std::unique_ptr<features::FeatureBuffer> queryBuffer_{};
   std::unordered_map<int, std::unordered_map<int, double>> costs_;
 
   std::optional<CostMatrix> precomputedCosts_ = {};
 };
+} // namespace localization::database
 
 #endif // SRC_DATABASE_ONLINE_DATABASE_H_

--- a/src/localization/database/online_database.h
+++ b/src/localization/database/online_database.h
@@ -32,6 +32,7 @@
 #include "features/feature_factory.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/src/localization/database/online_database.h
+++ b/src/localization/database/online_database.h
@@ -64,8 +64,7 @@ private:
   std::unique_ptr<FeatureBuffer> queryBuffer_{};
   std::unordered_map<int, std::unordered_map<int, double>> costs_;
 
-  // TODO(olga): Can it be here std::optional?
-  std::unique_ptr<CostMatrix> precomputedCosts_ = nullptr;
+  std::optional<CostMatrix> precomputedCosts_ = {};
 };
 
 #endif // SRC_DATABASE_ONLINE_DATABASE_H_

--- a/src/localization/database/online_database.h
+++ b/src/localization/database/online_database.h
@@ -26,6 +26,7 @@
 #ifndef SRC_DATABASE_ONLINE_DATABASE_H_
 #define SRC_DATABASE_ONLINE_DATABASE_H_
 
+#include "database/cost_matrix.h"
 #include "database/idatabase.h"
 #include "features/feature_buffer.h"
 #include "features/feature_factory.h"
@@ -43,7 +44,7 @@ class OnlineDatabase : public iDatabase {
 public:
   OnlineDatabase(const std::string &queryFeaturesDir,
                  const std::string &refFeaturesDir, FeatureType type,
-                 int bufferSize);
+                 int bufferSize, const std::string &costMatrixFile = "");
 
   inline int refSize() override { return refFeaturesNames_.size(); }
   double getCost(int quId, int refId) override;
@@ -63,7 +64,8 @@ private:
   std::unique_ptr<FeatureBuffer> queryBuffer_{};
   std::unordered_map<int, std::unordered_map<int, double>> costs_;
 
-  std::optional<CostMatrix> precomputedCosts;
+  // TODO(olga): Can it be here std::optional?
+  std::unique_ptr<CostMatrix> precomputedCosts_ = nullptr;
 };
 
 #endif // SRC_DATABASE_ONLINE_DATABASE_H_

--- a/src/localization/features/cnn_feature.cpp
+++ b/src/localization/features/cnn_feature.cpp
@@ -23,19 +23,17 @@
 
 /* Updated by O. Vysotska in 2022 */
 
-
 #include "cnn_feature.h"
 #include "features/ifeature.h"
 #include "localization_protos.pb.h"
 
-#include <math.h>
 #include <algorithm>
 #include <fstream>
 #include <limits>
+#include <math.h>
 #include <numeric>
 
 #include <glog/logging.h>
-
 
 CnnFeature::CnnFeature(const std::string &filename) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -73,25 +71,22 @@ void CnnFeature::binarize() {
 }
 
 double CnnFeature::computeSimilarityScore(const iFeature &rhs) const {
-  CHECK(this->type == rhs.type) <<  "Features are not the same type";
-  double norm_qr =
-      sqrt(std::inner_product(dimensions.begin(), dimensions.end(), dimensions.begin(), 0.0L));
+  CHECK(this->type == rhs.type) << "Features are not the same type";
+  double norm_qr = sqrt(std::inner_product(dimensions.begin(), dimensions.end(),
+                                           dimensions.begin(), 0.0L));
   double norm_db =
       sqrt(std::inner_product(rhs.dimensions.begin(), rhs.dimensions.end(),
                               rhs.dimensions.begin(), 0.0L));
   double prod_qr_db = std::inner_product(
       rhs.dimensions.begin(), rhs.dimensions.end(), dimensions.begin(), 0.0L);
-  double cos_dist = prod_qr_db / (norm_qr * norm_db);
-  return cos_dist;
+  double cos_similarity = prod_qr_db / (norm_qr * norm_db);
+  return cos_similarity;
 }
 
 double CnnFeature::score2cost(double score) const {
-  double cost;
   if (score < 1e-09) {
-    cost = std::numeric_limits<double>::max();
     printf("[INFO] The cost of comparing two images is suspiciously small.\n");
-  } else {
-    cost = 1. / score;
+    return std::numeric_limits<double>::max();
   }
-  return cost;
+  return 1. / score;
 }

--- a/src/localization/features/cnn_feature.cpp
+++ b/src/localization/features/cnn_feature.cpp
@@ -74,11 +74,11 @@ void CnnFeature::binarize() {
 
 double CnnFeature::computeSimilarityScore(const iFeature &rhs) const {
   CHECK(this->type == rhs.type) << "Features are not the same type";
-  double norm_qr = sqrt(std::inner_product(dimensions.begin(), dimensions.end(),
-                                           dimensions.begin(), 0.0L));
+  double norm_qr = std::sqrt(std::inner_product(
+      dimensions.begin(), dimensions.end(), dimensions.begin(), 0.0L));
   double norm_db =
-      sqrt(std::inner_product(rhs.dimensions.begin(), rhs.dimensions.end(),
-                              rhs.dimensions.begin(), 0.0L));
+      std::sqrt(std::inner_product(rhs.dimensions.begin(), rhs.dimensions.end(),
+                                   rhs.dimensions.begin(), 0.0L));
   double prod_qr_db = std::inner_product(
       rhs.dimensions.begin(), rhs.dimensions.end(), dimensions.begin(), 0.0L);
   double cos_similarity = prod_qr_db / (norm_qr * norm_db);

--- a/src/localization/features/cnn_feature.cpp
+++ b/src/localization/features/cnn_feature.cpp
@@ -35,6 +35,8 @@
 
 #include <glog/logging.h>
 
+namespace localization::features {
+
 CnnFeature::CnnFeature(const std::string &filename) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   image_sequence_localizer::Feature feature_proto;
@@ -90,3 +92,4 @@ double CnnFeature::score2cost(double score) const {
   }
   return 1. / score;
 }
+} // namespace localization::features

--- a/src/localization/features/cnn_feature.h
+++ b/src/localization/features/cnn_feature.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 
+namespace localization::features {
+
 /**
  * @brief      Class for cnn feature. By default binarizable with Mid
  * binarization
@@ -55,4 +57,5 @@ protected:
   void binarize();
 };
 
+} // namespace localization::features
 #endif // SRC_FEATURES_CNNFEATURE_H_

--- a/src/localization/features/cnn_feature.h
+++ b/src/localization/features/cnn_feature.h
@@ -33,10 +33,10 @@
  */
 class CnnFeature : public iFeature {
 public:
-
   CnnFeature(const std::string &filename);
 
-  // Computes the cosine distance between two vectors.
+  // Computes the cosine similarity between two vectors.
+  // The higher the score the more similar the features are.
   double computeSimilarityScore(const iFeature &rhs) const override;
   /**
    * @brief      weight/cost is an inverse of a score.

--- a/src/localization/features/feature_buffer.cpp
+++ b/src/localization/features/feature_buffer.cpp
@@ -29,6 +29,8 @@
 
 #include <glog/logging.h>
 
+namespace localization::features {
+
 FeatureBuffer::FeatureBuffer(int size) {
   LOG_IF(FATAL, size < 0) << "Invalid featureBuffer size.";
   bufferSize = size;
@@ -37,7 +39,7 @@ FeatureBuffer::FeatureBuffer(int size) {
 
 bool FeatureBuffer::inBuffer(int id) const { return featureMap.count(id) > 0; }
 
-const iFeature& FeatureBuffer::getFeature(int id) const {
+const iFeature &FeatureBuffer::getFeature(int id) const {
   return *featureMap.at(id);
 }
 
@@ -47,12 +49,15 @@ void FeatureBuffer::deleteFeature() {
   ids.erase(ids.begin());
 }
 
-void FeatureBuffer::addFeature(int id,  std::unique_ptr<iFeature>&& feature) {
+void FeatureBuffer::addFeature(int id, std::unique_ptr<iFeature> &&feature) {
 
   if (static_cast<int>(ids.size()) == bufferSize) {
     deleteFeature();
   }
   ids.push_back(id);
-  LOG_IF(WARNING, featureMap.count(id) > 0) << "Feature with id " << id << " exists. Overwriting..";
+  LOG_IF(WARNING, featureMap.count(id) > 0)
+      << "Feature with id " << id << " exists. Overwriting..";
   featureMap.emplace(id, std::move(feature));
 }
+
+} // namespace localization::features

--- a/src/localization/features/feature_buffer.h
+++ b/src/localization/features/feature_buffer.h
@@ -29,6 +29,8 @@
 #include <unordered_map>
 #include <vector>
 
+namespace localization::features {
+
 /**
  * @brief      Class for feature buffer. Stores the features kept in memory
  * during the search
@@ -38,8 +40,8 @@ public:
   FeatureBuffer(int size);
   bool inBuffer(int id) const;
   /** returns empty vector if a feature is not in buffer */
-  const iFeature& getFeature(int id) const;
-  void addFeature(int id, std::unique_ptr<iFeature>&& feature);
+  const iFeature &getFeature(int id) const;
+  void addFeature(int id, std::unique_ptr<iFeature> &&feature);
 
   void deleteFeature();
 
@@ -48,5 +50,7 @@ public:
   std::vector<int> ids;
   std::unordered_map<int, std::unique_ptr<iFeature>> featureMap;
 };
+
+} // namespace localization::features
 
 #endif // SRC_FEATURES_FEATURE_BUFFER_H_

--- a/src/localization/features/feature_factory.cpp
+++ b/src/localization/features/feature_factory.cpp
@@ -26,8 +26,10 @@
 
 #include <glog/logging.h>
 
+namespace localization::features {
+
 std::unique_ptr<iFeature> createFeature(FeatureType type,
-                            const std::string &featureFilename) {
+                                        const std::string &featureFilename) {
   switch (type) {
   case Cnn_Feature: {
     return std::make_unique<CnnFeature>(featureFilename);
@@ -35,3 +37,4 @@ std::unique_ptr<iFeature> createFeature(FeatureType type,
   }
   LOG(FATAL) << "Unknown feature type";
 }
+} // namespace localization::features

--- a/src/localization/features/feature_factory.h
+++ b/src/localization/features/feature_factory.h
@@ -26,11 +26,14 @@
 
 #include "features/ifeature.h"
 
+namespace localization::features {
+
 enum FeatureType {
   Cnn_Feature,
 };
 
 std::unique_ptr<iFeature> createFeature(FeatureType type,
-                            const std::string &featureFilename);
+                                        const std::string &featureFilename);
+} // namespace localization::features
 
 #endif // SRC_FEATURES_FEATURE_FACTORY_H_

--- a/src/localization/features/ifeature.h
+++ b/src/localization/features/ifeature.h
@@ -23,12 +23,14 @@
 
 /* Updated by O. Vysotska in 2022 */
 
-
 #ifndef SRC_FEATURES_IFEATURE_H_
 #define SRC_FEATURES_IFEATURE_H_
+
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace localization::features {
 
 /**
  * @brief      Interface class for features.
@@ -43,8 +45,7 @@ public:
    *
    * @return     One double value as a result of comparison.
    */
-  virtual double
-  computeSimilarityScore(const iFeature &rhs) const = 0;
+  virtual double computeSimilarityScore(const iFeature &rhs) const = 0;
   /**
    * @brief      Transforms similarity into the weights/cost for the graph.
 
@@ -73,5 +74,6 @@ public:
   just return the same value it takes as an input.
 
 */
+} // namespace localization::features
 
 #endif // SRC_FEATURES_IFEATURE_H_

--- a/src/localization/online_localizer/online_localizer.cpp
+++ b/src/localization/online_localizer/online_localizer.cpp
@@ -39,7 +39,7 @@
 #include <string>
 #include <vector>
 
-namespace online_localizer {
+namespace localization::online_localizer {
 
 using std::string;
 using std::vector;
@@ -69,8 +69,9 @@ void storeMatchesAsProto(const Matches &matches,
   LOG(INFO) << "The path was written to " << protoFilename;
 }
 
-OnlineLocalizer::OnlineLocalizer(SuccessorManager *successorManager,
-                                 double expansionRate, double nonMatchingCost) {
+OnlineLocalizer::OnlineLocalizer(
+    successor_manager::SuccessorManager *successorManager, double expansionRate,
+    double nonMatchingCost) {
 
   CHECK(successorManager) << "Successor manager is not set.";
   CHECK(expansionRate > 0 && expansionRate <= 1)
@@ -408,4 +409,4 @@ void OnlineLocalizer::visualize() const {
   _vis->drawPath(path);
 }
 
-} // namespace online_localizer
+} // namespace localization::online_localizer

--- a/src/localization/online_localizer/online_localizer.h
+++ b/src/localization/online_localizer/online_localizer.h
@@ -37,7 +37,7 @@
 #include "successor_manager/node.h"
 #include "successor_manager/successor_manager.h"
 
-namespace online_localizer {
+namespace localization::online_localizer {
 
 using Matches = std::vector<PathElement>;
 void storeMatchesAsProto(const Matches &matches,
@@ -49,8 +49,8 @@ public:
   using PredMap = std::unordered_map<int, std::unordered_map<int, Node>>;
   using AccCostsMap = std::unordered_map<int, std::unordered_map<int, double>>;
 
-  OnlineLocalizer(SuccessorManager *successorManager, double expansionRate,
-                  double nonMatchingCost);
+  OnlineLocalizer(successor_manager::SuccessorManager *successorManager,
+                  double expansionRate, double nonMatchingCost);
   ~OnlineLocalizer() {}
 
   Matches findMatchesTill(int queryId);
@@ -86,11 +86,11 @@ private:
   AccCostsMap accCosts_;
   Node currentBestHyp_;
 
-  SuccessorManager *successorManager_ = nullptr;
+  successor_manager::SuccessorManager *successorManager_ = nullptr;
   iLocVisualizer::Ptr _vis = nullptr;
 
   NodeSet expandedRecently_;
 };
-} // namespace online_localizer
+} // namespace localization::online_localizer
 
 #endif // SRC_ONLINE_LOCALIZER_ONLINE_LOCALIZER_H_

--- a/src/localization/relocalizers/CMakeLists.txt
+++ b/src/localization/relocalizers/CMakeLists.txt
@@ -4,11 +4,11 @@ target_link_libraries(lsh_cv_hashing
     online_database
     ${OpenCV_LIBS}
     cxx_flags
-	glog::glog
+    glog::glog
 )
 
 add_library(default_relocalizer default_relocalizer.cpp)
 target_link_libraries(default_relocalizer
     cxx_flags
-	glog::glog
+    glog::glog
 )

--- a/src/localization/relocalizers/CMakeLists.txt
+++ b/src/localization/relocalizers/CMakeLists.txt
@@ -6,3 +6,9 @@ target_link_libraries(lsh_cv_hashing
     cxx_flags
 	glog::glog
 )
+
+add_library(default_relocalizer default_relocalizer.cpp)
+target_link_libraries(default_relocalizer
+    cxx_flags
+	glog::glog
+)

--- a/src/localization/relocalizers/default_relocalizer.cpp
+++ b/src/localization/relocalizers/default_relocalizer.cpp
@@ -5,7 +5,7 @@
 DefaultRelocalizer::DefaultRelocalizer(int fanOut, int refSize)
     : fanOut_(fanOut), refSize_(refSize) {
   CHECK(fanOut_ > 0) << "Fan out should be positive.";
-  CHECK(refSize > 0) << "Fan out should be positive.";
+  CHECK(refSize > 0) << "RefSize should be positive.";
 }
 std::vector<int> DefaultRelocalizer::getCandidates(int quId) {
   std::vector<int> candidateIds;

--- a/src/localization/relocalizers/default_relocalizer.cpp
+++ b/src/localization/relocalizers/default_relocalizer.cpp
@@ -4,6 +4,8 @@
 
 #include <glog/logging.h>
 
+namespace localization::relocalizers {
+
 DefaultRelocalizer::DefaultRelocalizer(int fanOut, int refSize)
     : fanOut_(fanOut), refSize_(refSize) {
   CHECK(fanOut_ > 0) << "Fan out should be positive.";
@@ -17,3 +19,4 @@ std::vector<int> DefaultRelocalizer::getCandidates(int quId) {
   }
   return candidateIds;
 }
+} // namespace localization::relocalizers

--- a/src/localization/relocalizers/default_relocalizer.cpp
+++ b/src/localization/relocalizers/default_relocalizer.cpp
@@ -1,0 +1,17 @@
+#include "default_relocalizer.h"
+
+#include <glog/logging.h>
+
+DefaultRelocalizer::DefaultRelocalizer(int fanOut, int refSize)
+    : fanOut_(fanOut), refSize_(refSize) {
+  CHECK(fanOut_ > 0) << "Fan out should be positive.";
+  CHECK(refSize > 0) << "Fan out should be positive.";
+}
+std::vector<int> DefaultRelocalizer::getCandidates(int quId) {
+  std::vector<int> candidateIds;
+  for (int i = std::max(0, quId - fanOut_);
+       i <= std::min(refSize_, quId + fanOut_); i++) {
+    candidateIds.push_back(i);
+  }
+  return candidateIds;
+}

--- a/src/localization/relocalizers/default_relocalizer.cpp
+++ b/src/localization/relocalizers/default_relocalizer.cpp
@@ -1,3 +1,5 @@
+/* By O. Vysotska in 2023 */
+
 #include "default_relocalizer.h"
 
 #include <glog/logging.h>

--- a/src/localization/relocalizers/default_relocalizer.h
+++ b/src/localization/relocalizers/default_relocalizer.h
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+namespace localization::relocalizers {
+
 /**
  * Gives the candidates based on Fanout.
  */
@@ -18,5 +20,7 @@ private:
   int fanOut_ = 3;
   int refSize_ = -1;
 };
+
+} // namespace localization::relocalizers
 
 #endif // SRC_RELOCALIZERS_IRELOCALIZER_H_

--- a/src/localization/relocalizers/default_relocalizer.h
+++ b/src/localization/relocalizers/default_relocalizer.h
@@ -1,3 +1,5 @@
+/* By O. Vysotska in 2023 */
+
 #ifndef SRC_RELOCALIZERS_DEFAULT_RELOCALIZER_H_
 #define SRC_RELOCALIZERS_DEFAULT_RELOCALIZER_H_
 #include "relocalizers/irelocalizer.h"
@@ -5,7 +7,7 @@
 #include <vector>
 
 /**
- * @brief      Interface class for relocalizers
+ * Gives the candidates based on Fanout.
  */
 class DefaultRelocalizer : public iRelocalizer {
 public:

--- a/src/localization/relocalizers/default_relocalizer.h
+++ b/src/localization/relocalizers/default_relocalizer.h
@@ -1,0 +1,20 @@
+#ifndef SRC_RELOCALIZERS_DEFAULT_RELOCALIZER_H_
+#define SRC_RELOCALIZERS_DEFAULT_RELOCALIZER_H_
+#include "relocalizers/irelocalizer.h"
+#include <memory>
+#include <vector>
+
+/**
+ * @brief      Interface class for relocalizers
+ */
+class DefaultRelocalizer : public iRelocalizer {
+public:
+  DefaultRelocalizer(int fanOut, int refSize);
+  std::vector<int> getCandidates(int quId) override;
+
+private:
+  int fanOut_ = 3;
+  int refSize_ = -1;
+};
+
+#endif // SRC_RELOCALIZERS_IRELOCALIZER_H_

--- a/src/localization/relocalizers/irelocalizer.h
+++ b/src/localization/relocalizers/irelocalizer.h
@@ -26,6 +26,8 @@
 #include <memory>
 #include <vector>
 
+namespace localization::relocalizers {
+
 /**
  * @brief      Interface class for relocalizers
  */
@@ -43,5 +45,6 @@ public:
    */
   virtual std::vector<int> getCandidates(int quId) = 0;
 };
+} // namespace localization::relocalizers
 
 #endif // SRC_RELOCALIZERS_IRELOCALIZER_H_

--- a/src/localization/relocalizers/lsh_cv_hashing.cpp
+++ b/src/localization/relocalizers/lsh_cv_hashing.cpp
@@ -22,16 +22,17 @@
 **/
 
 #include "lsh_cv_hashing.h"
-
 #include "database/list_dir.h"
 #include "tools/timer/timer.h"
 
 #include <glog/logging.h>
 
+namespace localization::relocalizers {
+
 const int kMaxCandidateNum = 5;
 
-LshCvHashing::LshCvHashing(OnlineDatabase *database, int tableNum, int keySize,
-                           int multiProbeLevel) {
+LshCvHashing::LshCvHashing(database::OnlineDatabase *database, int tableNum,
+                           int keySize, int multiProbeLevel) {
   CHECK(database) << "Database is not set\n";
   database_ = database;
   indexParam_ =
@@ -39,7 +40,7 @@ LshCvHashing::LshCvHashing(OnlineDatabase *database, int tableNum, int keySize,
 }
 
 void LshCvHashing::train(
-    const std::vector<std::unique_ptr<iFeature>> &features) {
+    const std::vector<std::unique_ptr<features::iFeature>> &features) {
   matcherPtr_ =
       cv::Ptr<cv::FlannBasedMatcher>(new cv::FlannBasedMatcher(indexParam_));
   // transform to cv::Mat array of arrays
@@ -57,7 +58,7 @@ void LshCvHashing::train(
   LOG(INFO) << "Training completed";
 }
 
-std::vector<int> LshCvHashing::hashFeature(const iFeature &feature) {
+std::vector<int> LshCvHashing::hashFeature(const features::iFeature &feature) {
   std::vector<std::vector<cv::DMatch>> matches;
   cv::Mat featureCV(1, feature.bits.size(), CV_8UC1);
   for (int i = 0; i < feature.bits.size(); ++i) {
@@ -102,3 +103,4 @@ std::vector<int> LshCvHashing::getCandidates(int quId) {
   LOG(INFO) << "Candidates size: " << candidates.size();
   return candidates;
 }
+} // namespace localization::relocalizers

--- a/src/localization/relocalizers/lsh_cv_hashing.h
+++ b/src/localization/relocalizers/lsh_cv_hashing.h
@@ -27,13 +27,16 @@
 #include "database/online_database.h"
 #include "features/ifeature.h"
 #include "relocalizers/irelocalizer.h"
+
+#include "opencv2/features2d/features2d.hpp"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include "opencv2/features2d/features2d.hpp"
+namespace localization::relocalizers {
 
 /**
  * @brief      Performs locality sensitive hashing for angle-based similarity
@@ -44,23 +47,23 @@ public:
   /* tableNum - number of hash tables
      keySize - number of bits in the hash key
      multiProbeLevel - number of bits to shift to het neighbouring buckets */
-  LshCvHashing(OnlineDatabase *database, int tableNum = 25, int keySize = 25,
-               int multiProbeLevel = 2);
+  LshCvHashing(database::OnlineDatabase *database, int tableNum = 25,
+               int keySize = 25, int multiProbeLevel = 2);
 
   std::vector<int> getCandidates(int quId) override;
 
-  void train(const std::vector<std::unique_ptr<iFeature>> &features);
+  void train(const std::vector<std::unique_ptr<features::iFeature>> &features);
   /**
    * @brief      Not working for now, for unknown reason
    */
   void saveHashes();
 
-  std::vector<int> hashFeature(const iFeature &fPtr);
+  std::vector<int> hashFeature(const features::iFeature &fPtr);
 
 private:
   cv::Ptr<cv::FlannBasedMatcher> matcherPtr_;
   cv::Ptr<cv::flann::IndexParams> indexParam_;
-  OnlineDatabase *database_ = nullptr;
+  database::OnlineDatabase *database_ = nullptr;
 };
 
 // table_number the number of hash tables to use (between 10 and 30 usually).
@@ -68,4 +71,5 @@ private:
 // multi_probe_level the number of bits to shift to check for neighboring
 // buckets (0 is regular LSH, 2 is recommended).
 
+} // namespace localization::relocalizers
 #endif // SRC_RELOCALIZERS_LSH_CV_HASHING_H_

--- a/src/localization/successor_manager/CMakeLists.txt
+++ b/src/localization/successor_manager/CMakeLists.txt
@@ -5,7 +5,7 @@ cxx_flags
 
 add_library(successor_manager successor_manager.cpp)
 target_link_libraries(successor_manager
-	node 
-	cxx_flags
-	glog::glog
+    node 
+    cxx_flags
+    glog::glog
 )

--- a/src/localization/successor_manager/successor_manager.cpp
+++ b/src/localization/successor_manager/successor_manager.cpp
@@ -33,8 +33,11 @@
 #include <iostream>
 using std::vector;
 
-SuccessorManager::SuccessorManager(iDatabase *database,
-                                   iRelocalizer *relocalizer, int fanOut)
+namespace localization::successor_manager {
+
+SuccessorManager::SuccessorManager(database::iDatabase *database,
+                                   relocalizers::iRelocalizer *relocalizer,
+                                   int fanOut)
     : database_{database}, relocalizer_{relocalizer}, fanOut_{fanOut} {
   CHECK(database_ != nullptr) << "Database is not set.";
   CHECK(relocalizer_ != nullptr) << "Relocalizer is not set.";
@@ -93,7 +96,6 @@ std::unordered_set<Node> SuccessorManager::getSuccessors(const Node &node) {
   if (!_sameRefPlaces.empty()) {
     getSuccessorsSimPlaces(node.quId, node.refId);
   }
-  // printf("Successors were computed %d \n", _successors.size());
   return _successors;
 }
 
@@ -169,3 +171,4 @@ SuccessorManager::getSuccessorsIfLost(const Node &node) {
   }
   return _successors;
 }
+} // namespace localization::successor_manager

--- a/src/localization/successor_manager/successor_manager.h
+++ b/src/localization/successor_manager/successor_manager.h
@@ -35,13 +35,15 @@
 #include "relocalizers/irelocalizer.h"
 #include "successor_manager/node.h"
 
+namespace localization::successor_manager {
 /**
  * @brief      Class that communicates between database and localizer.
  *             Knows how to maintain successor.
  */
 class SuccessorManager {
 public:
-  SuccessorManager(iDatabase *database, iRelocalizer *relocalizer, int fanOut);
+  SuccessorManager(database::iDatabase *database,
+                   relocalizers::iRelocalizer *relocalizer, int fanOut);
   ~SuccessorManager() {}
 
   /**
@@ -61,7 +63,7 @@ public:
   void getSuccessorsSimPlaces(int quId, int refId);
 
 protected:
-  iDatabase *database_ = nullptr;
+  database::iDatabase *database_ = nullptr;
   int fanOut_ = 0;
 
 private:
@@ -71,7 +73,8 @@ private:
    * for refId gives the vector of refIds, that represent similar places
    */
   std::unordered_map<int, std::set<int>> _sameRefPlaces;
-  iRelocalizer *relocalizer_ = nullptr;
+  relocalizers::iRelocalizer *relocalizer_ = nullptr;
 };
+} // namespace localization::successor_manager
 
 #endif // SRC_SUCCESSOR_MANAGER_SUCCESSOR_MANAGER_H_

--- a/src/python/run_matching.py
+++ b/src/python/run_matching.py
@@ -116,9 +116,7 @@ def computeCostMatrix(config):
 
 
 def runMatching(config_yaml_file):
-    binary = (
-        "../../build/src/apps/cost_matrix_based_matching/cost_matrix_based_matching_lsh"
-    )
+    binary = "../../build/src/apps/cost_matrix_based_matching/online_localizer_lsh"
     command = binary + " " + str(config_yaml_file)
     print("Calling:", command)
     os.system(command)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -9,14 +9,16 @@ set(TESTNAME test_${PROJECT_NAME})
 # )
 
 add_executable(${TESTNAME} 
+    cost_matrix_test.cpp
     database_test.cpp
     feature_buffer_test.cpp
     online_localizer_test.cpp
 )
 target_link_libraries(${TESTNAME} 
+    cost_matrix
     cnn_feature
     feature_buffer
-    cost_matrix_database
+    online_database
     successor_manager
     online_localizer
     list_dir

--- a/src/test/cost_matrix_test.cpp
+++ b/src/test/cost_matrix_test.cpp
@@ -7,6 +7,8 @@
 #include "gtest/gtest.h"
 #include <filesystem>
 
+namespace test {
+
 class CostMatrixTest : public ::testing::Test {
 public:
   void SetUp() {
@@ -46,18 +48,20 @@ public:
 };
 
 TEST_F(CostMatrixTest, ConstructFromProto) {
-  auto costMatrix = CostMatrix(costMatrixFile);
+  auto costMatrix = localization::database::CostMatrix(costMatrixFile);
   EXPECT_EQ(costMatrix.rows(), this->costMatrixValues.size());
   EXPECT_EQ(costMatrix.cols(), this->costMatrixValues[0].size());
 }
 
 TEST_F(CostMatrixTest, FailedToConstruct) {
-  ASSERT_DEATH(CostMatrix(""), "Cost matrix file is not set");
+  ASSERT_DEATH(localization::database::CostMatrix(""),
+               "Cost matrix file is not set");
 }
 
 TEST_F(CostMatrixTest, at) {
-  auto costMatrix = CostMatrix(costMatrixFile);
-  Matrix expectedMatrix = this->costMatrixValues;
+  auto costMatrix = localization::database::CostMatrix(costMatrixFile);
+  localization::database::CostMatrix::Matrix expectedMatrix =
+      this->costMatrixValues;
   EXPECT_EQ(costMatrix.rows(), expectedMatrix.size());
   EXPECT_EQ(costMatrix.cols(), expectedMatrix[0].size());
 
@@ -73,8 +77,9 @@ TEST_F(CostMatrixTest, at) {
 }
 
 TEST_F(CostMatrixTest, getInverseCost) {
-  auto costMatrix = CostMatrix(costMatrixFile);
+  auto costMatrix = localization::database::CostMatrix(costMatrixFile);
   EXPECT_DOUBLE_EQ(costMatrix.getInverseCost(0, 0), 1);
   EXPECT_NEAR(costMatrix.getInverseCost(1, 0), 1 / this->costMatrixValues[1][0],
               1e-06);
 }
+} // namespace test

--- a/src/test/cost_matrix_test.cpp
+++ b/src/test/cost_matrix_test.cpp
@@ -1,0 +1,61 @@
+// #include "database/online_database.h"
+#include "database/cost_matrix.h"
+#include "localization_protos.pb.h"
+#include "test_utils.h"
+
+#include "gtest/gtest.h"
+#include <filesystem>
+
+class CostMatrixTest : public ::testing::Test {
+public:
+  void SetUp() {
+    tmp_dir = localization::test::createDataForOnlineDatabase();
+    std::filesystem::path featureDir = tmp_dir;
+    image_sequence_localizer::CostMatrix cost_matrix =
+        localization::test::computeCostMatrix(featureDir, featureDir);
+    costMatrixFile = tmp_dir / "test.CostMatrix.pb";
+    std::fstream out(costMatrixFile,
+                     std::ios::out | std::ios::trunc | std::ios::binary);
+    cost_matrix.SerializeToOstream(&out);
+    out.close();
+  }
+
+  std::filesystem::path tmp_dir = "";
+  std::string costMatrixFile = "";
+};
+
+TEST_F(CostMatrixTest, ConstructFromProto) {
+  auto costMatrix = CostMatrix(costMatrixFile);
+  EXPECT_EQ(costMatrix.rows(), 4);
+  EXPECT_EQ(costMatrix.cols(), 4);
+}
+
+TEST_F(CostMatrixTest, FailedToConstruct) {
+  ASSERT_DEATH(CostMatrix(""), "Cost matrix file is not set");
+}
+
+TEST_F(CostMatrixTest, at) {
+  auto costMatrix = CostMatrix(costMatrixFile);
+  Matrix expectedMatrix = {{1, 0.922225, 0.285714, 0.99449},
+                           {0.922225, 1, 0.634029, 0.922876},
+                           {0.285714, 0.634029, 1, 0.298347},
+                           {0.99449, 0.922876, 0.298347, 1}};
+  EXPECT_EQ(costMatrix.rows(), expectedMatrix.size());
+  EXPECT_EQ(costMatrix.cols(), expectedMatrix[0].size());
+
+  for (int r = 0; r < costMatrix.rows(); ++r) {
+    for (int c = 0; c < costMatrix.cols(); ++c) {
+      EXPECT_NEAR(costMatrix.at(r, c), expectedMatrix[r][c], 1e-06);
+    }
+  }
+  ASSERT_DEATH(costMatrix.at(-1, 0), "Row outside range -1");
+  ASSERT_DEATH(costMatrix.at(4, 0), "Row outside range 4");
+  ASSERT_DEATH(costMatrix.at(0, -1), "Col outside range -1");
+  ASSERT_DEATH(costMatrix.at(0, 4), "Col outside range 4");
+}
+
+TEST_F(CostMatrixTest, getInverseCost) {
+  auto costMatrix = CostMatrix(costMatrixFile);
+  EXPECT_DOUBLE_EQ(costMatrix.getInverseCost(0, 0), 1);
+  EXPECT_NEAR(costMatrix.getInverseCost(1, 0), 1 / 0.922225, 1e-06);
+}

--- a/src/test/cost_matrix_test.cpp
+++ b/src/test/cost_matrix_test.cpp
@@ -82,4 +82,17 @@ TEST_F(CostMatrixTest, getInverseCost) {
   EXPECT_NEAR(costMatrix.getInverseCost(1, 0), 1 / this->costMatrixValues[1][0],
               1e-06);
 }
+
+TEST(CostMatrixComputation, createCostMatrixFromFeatures) {
+  const fs::path tmp_dir = test::createFeatures();
+
+  auto costMatrix = localization::database::CostMatrix(
+      tmp_dir, tmp_dir, localization::features::Cnn_Feature);
+
+  for (int r = 0; r < costMatrix.rows(); ++r) {
+    for (int c = 0; c < costMatrix.cols(); ++c) {
+      EXPECT_NEAR(costMatrix.at(r, c), kCostMatrix[r][c], kTestEpsilon);
+    }
+  }
+}
 } // namespace test

--- a/src/test/database_test.cpp
+++ b/src/test/database_test.cpp
@@ -97,55 +97,36 @@ TEST_F(OnlineDatabaseTest, InvalidConstructorParams) {
 
 TEST_F(OnlineDatabaseTest, NoCostMatrixFile) {
 
-  ASSERT_DEATH(CostMatrixDatabase(tmp_dir, tmp_dir, tmp_dir,
-                                  FeatureType::Cnn_Feature, 10),
-               "Failed to parse cost_matrix file: ");
+  ASSERT_DEATH(
+      OnlineDatabase(tmp_dir, tmp_dir, FeatureType::Cnn_Feature, 10, tmp_dir),
+      "Failed to parse cost_matrix file: ");
 }
 
 TEST_F(OnlineDatabaseTest, CostMatrixDatabaseConstructor) {
   std::string cost_matrix_name = createCostMatrixProto(tmp_dir);
-  CostMatrixDatabase database(cost_matrix_name,
-                              /*queryFeaturesDir=*/tmp_dir,
-                              /*refFeaturesDir=*/tmp_dir,
-                              /*type=*/FeatureType::Cnn_Feature,
-                              /*bufferSize=*/10);
+  OnlineDatabase database(/*queryFeaturesDir=*/tmp_dir,
+                          /*refFeaturesDir=*/tmp_dir,
+                          /*type=*/FeatureType::Cnn_Feature,
+                          /*bufferSize=*/10, cost_matrix_name);
   EXPECT_EQ(database.getCost(0, 0), 1);
   EXPECT_DOUBLE_EQ(database.getCost(0, 2), 1. / 3);
   EXPECT_DOUBLE_EQ(database.getCost(1, 0), 1. / 4);
   EXPECT_DOUBLE_EQ(database.getCost(1, 2), 1. / 6);
-}
-
-TEST_F(OnlineDatabaseTest, CostMatrixDatabaseRefSize) {
-  std::string cost_matrix_name = createCostMatrixProto(tmp_dir);
-  CostMatrixDatabase database(cost_matrix_name,
-                              /*queryFeaturesDir=*/tmp_dir,
-                              /*refFeaturesDir=*/tmp_dir,
-                              /*type=*/FeatureType::Cnn_Feature,
-                              /*bufferSize=*/10);
-  EXPECT_EQ(database.refSize(), 3);
-  database.overrideCosts(
-      {
-          {1, 2, 3, 8},
-          {4, 5, 6, 7},
-      },
-      2, 4);
-  EXPECT_EQ(database.refSize(), 4);
 }
 
 TEST_F(OnlineDatabaseTest, CostMatrixDatabaseGetCost) {
   std::string cost_matrix_name = createCostMatrixProto(tmp_dir);
-  CostMatrixDatabase database(cost_matrix_name,
-                              /*queryFeaturesDir=*/tmp_dir,
-                              /*refFeaturesDir=*/tmp_dir,
-                              /*type=*/FeatureType::Cnn_Feature,
-                              /*bufferSize=*/10);
+  OnlineDatabase database(/*queryFeaturesDir=*/tmp_dir,
+                          /*refFeaturesDir=*/tmp_dir,
+                          /*type=*/FeatureType::Cnn_Feature,
+                          /*bufferSize=*/10, cost_matrix_name);
   EXPECT_EQ(database.getCost(0, 0), 1);
   EXPECT_DOUBLE_EQ(database.getCost(0, 2), 1. / 3);
   EXPECT_DOUBLE_EQ(database.getCost(1, 0), 1. / 4);
   EXPECT_DOUBLE_EQ(database.getCost(1, 2), 1. / 6);
-  ASSERT_DEATH(database.getCost(-1, 0), "Invalid query index -1");
-  ASSERT_DEATH(database.getCost(0, -1), "Invalid reference index -1");
-  ASSERT_DEATH(database.getCost(3, 0), "Invalid query index 3");
-  ASSERT_DEATH(database.getCost(0, 4), "Invalid reference index 4");
+  ASSERT_DEATH(database.getCost(-1, 0), "Row outside range -1");
+  ASSERT_DEATH(database.getCost(0, -1), "Col outside range -1");
+  ASSERT_DEATH(database.getCost(3, 0), "Row outside range 3");
+  ASSERT_DEATH(database.getCost(0, 4), "Col outside range 4");
 }
 } // namespace localization

--- a/src/test/database_test.cpp
+++ b/src/test/database_test.cpp
@@ -61,9 +61,9 @@ protected:
     out.close();
     return cost_matrix_name;
   }
-  void SetUp() { tmp_dir = test::createDataForOnlineDatabase(); }
+  void SetUp() { tmp_dir = test::createFeatures(); }
   void TearDown() {
-    test::clearDataForOnlineDatabase(tmp_dir);
+    test::clearDataUnderPath(tmp_dir);
     tmp_dir = "";
   }
   std::filesystem::path tmp_dir = "";

--- a/src/test/feature_buffer_test.cpp
+++ b/src/test/feature_buffer_test.cpp
@@ -31,18 +31,21 @@
 #include <string>
 #include <vector>
 
-class DummyFeature : public iFeature {
+namespace test {
+
+namespace loc_features = localization::features;
+
+class DummyFeature : public loc_features::iFeature {
 public:
   DummyFeature(const std::vector<double> &values) { dimensions = values; }
   double computeSimilarityScore(const iFeature &rhs) const override {
     return 0.0;
   }
   double score2cost(double score) const override { return 0.0; }
-
 };
 
 TEST(featureBuffer, addFeature) {
-  FeatureBuffer buffer(2);
+  loc_features::FeatureBuffer buffer(2);
 
   buffer.addFeature(0,
                     std::make_unique<DummyFeature>(std::vector{1.0, 2.0, 3.0}));
@@ -60,7 +63,7 @@ TEST(featureBuffer, addFeature) {
 }
 
 TEST(featureBuffer, inBuffer) {
-  FeatureBuffer buffer(4);
+  loc_features::FeatureBuffer buffer(4);
   EXPECT_FALSE(buffer.inBuffer(4));
 
   buffer.addFeature(1,
@@ -70,11 +73,12 @@ TEST(featureBuffer, inBuffer) {
 }
 
 TEST(featureBuffer, getFeature) {
-  FeatureBuffer buffer(4);
+  loc_features::FeatureBuffer buffer(4);
   buffer.addFeature(1,
                     std::make_unique<DummyFeature>(std::vector{4.0, 5.0, 6.0}));
-  const auto &feature =buffer.getFeature(1);
+  const auto &feature = buffer.getFeature(1);
   EXPECT_DOUBLE_EQ(feature.dimensions[0], 4);
   EXPECT_DOUBLE_EQ(feature.dimensions[1], 5);
   EXPECT_DOUBLE_EQ(feature.dimensions[2], 6);
 }
+} // namespace test

--- a/src/test/online_localizer_test.cpp
+++ b/src/test/online_localizer_test.cpp
@@ -1,5 +1,6 @@
 
 #include "database/cost_matrix_database.h"
+#include "database/online_database.h"
 #include "features/ifeature.h"
 #include "localization_protos.pb.h"
 #include "online_localizer/online_localizer.h"
@@ -33,8 +34,8 @@ public:
     cost_matrix.SerializeToOstream(&out);
     out.close();
 
-    database = std::make_unique<CostMatrixDatabase>(
-        costMatrixFile, featureDir, featureDir, FeatureType::Cnn_Feature, 10);
+    database = std::make_unique<OnlineDatabase>(
+        featureDir, featureDir, FeatureType::Cnn_Feature, 10, costMatrixFile);
     relocalizer = std::make_unique<FakeRelocalizer>();
     successorManager = std::make_unique<SuccessorManager>(database.get(),
                                                           relocalizer.get(), 2);

--- a/src/test/online_localizer_test.cpp
+++ b/src/test/online_localizer_test.cpp
@@ -26,10 +26,10 @@ public:
 class OnlineLocalizerTest : public ::testing::Test {
 public:
   void SetUp() {
-    tmp_dir = test::createDataForOnlineDatabase();
+    tmp_dir = test::createFeatures();
     std::filesystem::path featureDir = tmp_dir;
     image_sequence_localizer::CostMatrix cost_matrix =
-        test::computeCostMatrix(featureDir, featureDir);
+        test::computeCostMatrixProto(featureDir, featureDir);
     std::string costMatrixFile = tmp_dir / "test.CostMatrix.pb";
     std::fstream out(costMatrixFile,
                      std::ios::out | std::ios::trunc | std::ios::binary);
@@ -46,6 +46,12 @@ public:
     localizer = std::make_unique<loc::online_localizer::OnlineLocalizer>(
         successorManager.get(), 1.0, 100.0);
   }
+
+  void TearDown() {
+    test::clearDataUnderPath(tmp_dir);
+    tmp_dir = "";
+  }
+
   std::unique_ptr<loc::online_localizer::OnlineLocalizer> localizer = nullptr;
   std::unique_ptr<loc::successor_manager::SuccessorManager> successorManager =
       nullptr;

--- a/src/test/successor_manager_test.cpp
+++ b/src/test/successor_manager_test.cpp
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 
-namespace localization {
+namespace test {
 
 namespace fs = std::filesystem;
 
@@ -19,14 +19,17 @@ protected:
 };
 
 TEST_F(SuccessorManagerTest, create) {
-  ASSERT_DEATH(SuccessorManager(nullptr, nullptr, /*fanOut=*/0),
+  ASSERT_DEATH(localization::successor_manager::SuccessorManager(
+                   nullptr, nullptr, /*fanOut=*/0),
                "Database is not set.");
   // Create test database.
-  OnlineDatabase database(/*queryFeaturesDir=*/tmp_dir,
-                          /*refFeaturesDir=*/tmp_dir,
-                          /*type=*/FeatureType::Cnn_Feature,
-                          /*bufferSize=*/10);
-  ASSERT_DEATH(SuccessorManager(&database, nullptr, /*fanOut=*/0),
+  localization::database::OnlineDatabase database(
+      /*queryFeaturesDir=*/tmp_dir,
+      /*refFeaturesDir=*/tmp_dir,
+      localization::features::FeatureType::Cnn_Feature,
+      /*bufferSize=*/10);
+  ASSERT_DEATH(localization::successor_manager::SuccessorManager(
+                   &database, nullptr, /*fanOut=*/0),
                "Relocalizer is not set.");
 }
-} // namespace localization
+} // namespace test

--- a/src/test/successor_manager_test.cpp
+++ b/src/test/successor_manager_test.cpp
@@ -10,9 +10,9 @@ namespace fs = std::filesystem;
 
 class SuccessorManagerTest : public ::testing::Test {
 protected:
-  void SetUp() { tmp_dir = test::createDataForOnlineDatabase(); }
+  void SetUp() { tmp_dir = test::createFeatures(); }
   void TearDown() {
-    test::clearDataForOnlineDatabase(tmp_dir);
+    test::clearDataUnderPath(tmp_dir);
     tmp_dir = "";
   }
   fs::path tmp_dir = "";

--- a/src/test/test_utils.h
+++ b/src/test/test_utils.h
@@ -5,6 +5,7 @@
 #include "database/list_dir.h"
 #include "database/online_database.h"
 #include "features/cnn_feature.h"
+#include "features/feature_factory.h"
 #include "localization_protos.pb.h"
 
 #include "gtest/gtest.h"
@@ -15,7 +16,6 @@
 #include <string>
 #include <vector>
 
-namespace localization {
 namespace test {
 
 namespace fs = std::filesystem;
@@ -66,15 +66,16 @@ inline image_sequence_localizer::CostMatrix
 computeCostMatrix(const fs::path &queryDir, const fs::path &refDir) {
 
   const std::vector<std::string> queryFiles =
-      listProtoDir(queryDir, ".Feature");
-  const std::vector<std::string> refFiles = listProtoDir(refDir, ".Feature");
+      localization::database::listProtoDir(queryDir, ".Feature");
+  const std::vector<std::string> refFiles =
+      localization::database::listProtoDir(refDir, ".Feature");
   image_sequence_localizer::CostMatrix cost_matrix;
 
   for (const auto &query : queryFiles) {
-    const auto queryFeature = CnnFeature(query);
+    const auto queryFeature = localization::features::CnnFeature(query);
     for (const auto &ref : refFiles) {
-      cost_matrix.add_values(
-          queryFeature.computeSimilarityScore(CnnFeature(ref)));
+      cost_matrix.add_values(queryFeature.computeSimilarityScore(
+          localization::features::CnnFeature(ref)));
     }
   }
 
@@ -84,6 +85,5 @@ computeCostMatrix(const fs::path &queryDir, const fs::path &refDir) {
 }
 
 } // namespace test
-} // namespace localization
 
 #endif // TEST_TEST_UTILS_H_

--- a/src/test/test_utils.h
+++ b/src/test/test_utils.h
@@ -1,9 +1,7 @@
 #ifndef TEST_TEST_UTILS_H_
 #define TEST_TEST_UTILS_H_
 
-#include "database/cost_matrix_database.h"
 #include "database/list_dir.h"
-#include "database/online_database.h"
 #include "features/cnn_feature.h"
 #include "features/feature_factory.h"
 #include "localization_protos.pb.h"
@@ -17,6 +15,8 @@
 #include <vector>
 
 namespace test {
+
+constexpr auto kTestEpsilon = 1e-06;
 
 namespace fs = std::filesystem;
 
@@ -43,7 +43,7 @@ createFeatureFile(const std::filesystem::path &dir, const std::string &name,
   output.close();
 }
 
-inline std::filesystem::path createDataForOnlineDatabase() {
+inline std::filesystem::path createFeatures() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   std::filesystem::path tmp_dir =
       std::filesystem::temp_directory_path() / "features";
@@ -58,12 +58,18 @@ inline std::filesystem::path createDataForOnlineDatabase() {
                     createFeatureProto({0, 1, 2.5, 3}));
   return tmp_dir;
 }
-inline void clearDataForOnlineDatabase(const std::filesystem::path &path) {
+inline void clearDataUnderPath(const std::filesystem::path &path) {
   std::filesystem::remove_all(path);
 }
 
+const std::vector<std::vector<double>> kCostMatrix = {
+    {1, 0.922225, 0.285714, 0.99449},
+    {0.922225, 1, 0.634029, 0.922876},
+    {0.285714, 0.634029, 1, 0.298347},
+    {0.99449, 0.922876, 0.298347, 1}};
+
 inline image_sequence_localizer::CostMatrix
-computeCostMatrix(const fs::path &queryDir, const fs::path &refDir) {
+computeCostMatrixProto(const fs::path &queryDir, const fs::path &refDir) {
 
   const std::vector<std::string> queryFiles =
       localization::database::listProtoDir(queryDir, ".Feature");


### PR DESCRIPTION
This PR separates the loading cost matrix as a separate class.
This allows running online_localizer in an "offline fashion". Basically, having only a cost matrix, the code now can run a search with the default relocalizer without requiring features files to be present. This, however, practically disables the "relocalization" so the search "can't jump" to a new location. The `default relocalizer` mimics the same expansion pattern as online search since it has no additional information about the features.

This PR also update the `CostMatrixDatabase`. It is not an OnlineDatabase anymore but directly inherits from iDatabase interface.

The `OnlineDatabase` now has a cost matrix is an optional parameter for faster search if you have by any chance already precomputed your cost matrix.