### PR TITLE
Adds the binary for pure hashing instead of sequence matching

### DIFF
--- a/src/apps/cost_matrix_based_matching/CMakeLists.txt
+++ b/src/apps/cost_matrix_based_matching/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(OpenCV REQUIRED)
 add_executable(online_localizer_lsh online_localizer_lsh.cpp)
 target_link_libraries(online_localizer_lsh
     glog::glog
+    path_element
     online_localizer
     cost_matrix_database
     successor_manager
@@ -16,6 +17,7 @@ target_link_libraries(online_localizer_lsh
 add_executable(cost_matrix_no_hashing cost_matrix_no_hashing.cpp)
 target_link_libraries(cost_matrix_no_hashing
     glog::glog
+    path_element
     online_localizer
     cost_matrix_database
     successor_manager
@@ -23,3 +25,15 @@ target_link_libraries(cost_matrix_no_hashing
     default_relocalizer
     ${OpenCV_LIBS} 
 )
+
+add_executable(localization_by_hashing localization_by_hashing.cpp)
+target_link_libraries(localization_by_hashing
+    glog::glog
+    cnn_feature
+    path_element
+    cost_matrix_database
+    config_parser
+    lsh_cv_hashing
+    ${OpenCV_LIBS} 
+)
+

--- a/src/apps/cost_matrix_based_matching/cost_matrix_no_hashing.cpp
+++ b/src/apps/cost_matrix_based_matching/cost_matrix_no_hashing.cpp
@@ -3,6 +3,7 @@
 #include "database/cost_matrix_database.h"
 #include "database/idatabase.h"
 #include "online_localizer/online_localizer.h"
+#include "online_localizer/path_element.h"
 #include "relocalizers/default_relocalizer.h"
 #include "successor_manager/successor_manager.h"
 #include "tools/config_parser/config_parser.h"

--- a/src/apps/cost_matrix_based_matching/localization_by_hashing.cpp
+++ b/src/apps/cost_matrix_based_matching/localization_by_hashing.cpp
@@ -1,0 +1,94 @@
+// Created by O.Vysotska in 2023
+
+#include "database/idatabase.h"
+#include "database/list_dir.h"
+#include "database/online_database.h"
+#include "features/cnn_feature.h"
+#include "features/ifeature.h"
+#include "online_localizer/path_element.h"
+#include "relocalizers/lsh_cv_hashing.h"
+#include "tools/config_parser/config_parser.h"
+
+#include <glog/logging.h>
+
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+
+namespace loc = localization;
+
+std::vector<std::unique_ptr<loc::features::iFeature>>
+loadFeatures(const std::string &path2folder) {
+  LOG(INFO) << "Loading the features to hash with LSH.";
+  std::vector<std::string> featureNames =
+      loc::database::listProtoDir(path2folder, ".Feature");
+  std::vector<std::unique_ptr<loc::features::iFeature>> features;
+
+  for (size_t i = 0; i < featureNames.size(); ++i) {
+    features.emplace_back(
+        std::make_unique<loc::features::CnnFeature>(featureNames[i]));
+    fprintf(stderr, ".");
+  }
+  fprintf(stderr, "\n");
+  LOG(INFO) << "Features were loaded and binarized";
+  return features;
+}
+
+int main(int argc, char *argv[]) {
+  google::InitGoogleLogging(argv[0]);
+  FLAGS_logtostderr = 1;
+  LOG(INFO) << "===== Place recognition using pure Hashing algorithm ====\n";
+
+  if (argc < 2) {
+    printf("[ERROR] Not enough input parameters.\n");
+    printf("Proper usage: ./localization_by_hashing config_file.yaml\n");
+    exit(0);
+  }
+
+  std::string config_file = argv[1];
+  ConfigParser parser;
+  parser.parseYaml(config_file);
+  parser.print();
+
+  const auto database = std::make_unique<loc::database::OnlineDatabase>(
+      /*queryFeaturesDir=*/parser.path2qu,
+      /*refFeaturesDir=*/parser.path2ref,
+      /*type=*/loc::features::FeatureType::Cnn_Feature,
+      /*bufferSize=*/parser.bufferSize,
+      /*costMatrixFile=*/parser.costMatrix);
+
+  auto relocalizer = std::make_unique<loc::relocalizers::LshCvHashing>(
+      /*onlineDatabase=*/database.get(),
+      /*tableNum=*/1,
+      /*keySize=*/12,
+      /*multiProbeLevel=*/2);
+  relocalizer->train(loadFeatures(parser.path2ref));
+
+  loc::online_localizer::Matches matches;
+  for (int queryId = 0; queryId < parser.querySize; ++queryId) {
+    loc::online_localizer::PathElement pathElement;
+    std::vector<int> candidates = relocalizer->getCandidates(queryId);
+    double minCost = std::numeric_limits<double>::max();
+    int refId = -1;
+    for (int candidateId : candidates) {
+      double cost = database->getCost(queryId, candidateId);
+      if (cost < minCost) {
+        minCost = cost;
+        refId = candidateId;
+      }
+    }
+    if (refId == -1) {
+      // no candidates found
+      matches.emplace_back(queryId, 0,
+                           loc::online_localizer::NodeState::HIDDEN);
+    } else {
+      matches.emplace_back(queryId, refId,
+                           loc::online_localizer::NodeState::REAL);
+    }
+  }
+  loc::online_localizer::storeMatchesAsProto(matches, parser.matchingResult);
+
+  LOG(INFO) << "Done.";
+  return 0;
+}

--- a/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
+++ b/src/apps/cost_matrix_based_matching/online_localizer_lsh.cpp
@@ -26,8 +26,9 @@
 #include "database/online_database.h"
 #include "features/cnn_feature.h"
 #include "features/ifeature.h"
-#include "online_localizer/ilocvisualizer.h"
+// #include "online_localizer/ilocvisualizer.h"
 #include "online_localizer/online_localizer.h"
+#include "online_localizer/path_element.h"
 #include "relocalizers/lsh_cv_hashing.h"
 #include "successor_manager/successor_manager.h"
 #include "tools/config_parser/config_parser.h"
@@ -97,6 +98,6 @@ int main(int argc, char *argv[]) {
   loc::online_localizer::storeMatchesAsProto(imageMatches,
                                              parser.matchingResult);
 
-  printf("Done.\n");
+  LOG(INFO) << "Done.";
   return 0;
 }

--- a/src/localization/online_localizer/CMakeLists.txt
+++ b/src/localization/online_localizer/CMakeLists.txt
@@ -1,9 +1,16 @@
+add_library(path_element path_element.cpp)
+target_link_libraries(path_element
+	cxx_flags
+	protos
+	glog::glog
+)
+
 add_library(online_localizer 
-	online_localizer.cpp 
-	path_element.cpp
+	online_localizer.cpp
 )
 target_link_libraries(online_localizer
 	cxx_flags
+	path_element
 	successor_manager
 	node
 	timer

--- a/src/localization/online_localizer/ilocvisualizer.h
+++ b/src/localization/online_localizer/ilocvisualizer.h
@@ -32,19 +32,22 @@
 #include "online_localizer/path_element.h"
 #include "successor_manager/node.h"
 
+namespace localization::online_localizer {
+
 /**
  * @brief      interface to visualize the localizer. To write your own
  * visualizer inherit from this class.
  */
 class iLocVisualizer {
-   public:
-    using Ptr = std::shared_ptr<iLocVisualizer>;
-    using ConstPtr = std::shared_ptr<const iLocVisualizer>;
+public:
+  using Ptr = std::shared_ptr<iLocVisualizer>;
+  using ConstPtr = std::shared_ptr<const iLocVisualizer>;
 
-    virtual void drawPath(const std::vector<PathElement> &path) = 0;
-    virtual void drawFrontier(const std::unordered_set<Node> &frontier) = 0;
-    virtual void drawExpansion(NodeSet expansion) = 0;
-    virtual void processFinished() = 0;
+  virtual void drawPath(const std::vector<PathElement> &path) = 0;
+  virtual void drawFrontier(const std::unordered_set<Node> &frontier) = 0;
+  virtual void drawExpansion(NodeSet expansion) = 0;
+  virtual void processFinished() = 0;
 };
+}; // namespace localization::online_localizer
 
-#endif  // SRC_ONLINE_LOCALIZER_ILOCVISUALIZER_H_
+#endif // SRC_ONLINE_LOCALIZER_ILOCVISUALIZER_H_

--- a/src/localization/online_localizer/online_localizer.cpp
+++ b/src/localization/online_localizer/online_localizer.cpp
@@ -46,29 +46,6 @@ using std::vector;
 
 const float kMaxLostNodesRatio = 0.8; // 80%
 
-void storeMatchesAsProto(const Matches &matches,
-                         const std::string &protoFilename) {
-  image_sequence_localizer::MatchingResult matching_result_proto;
-
-  for (const auto &match : matches) {
-    image_sequence_localizer::MatchingResult::Match *match_proto =
-        matching_result_proto.add_matches();
-    match_proto->set_query_id(match.quId);
-    match_proto->set_ref_id(match.refId);
-    match_proto->set_real(match.state == NodeState::HIDDEN ? 0 : 1);
-  }
-
-  std::fstream out(protoFilename,
-                   std::ios::out | std::ios::trunc | std::ios::binary);
-  if (!matching_result_proto.SerializeToOstream(&out)) {
-    LOG(ERROR) << "Couldn't open the file " << protoFilename;
-    LOG(ERROR) << "The path is NOT saved.";
-    return;
-  }
-  out.close();
-  LOG(INFO) << "The path was written to " << protoFilename;
-}
-
 OnlineLocalizer::OnlineLocalizer(
     successor_manager::SuccessorManager *successorManager, double expansionRate,
     double nonMatchingCost) {

--- a/src/localization/online_localizer/online_localizer.h
+++ b/src/localization/online_localizer/online_localizer.h
@@ -39,10 +39,6 @@
 
 namespace localization::online_localizer {
 
-using Matches = std::vector<PathElement>;
-void storeMatchesAsProto(const Matches &matches,
-                         const std::string &protoFilename);
-
 // Performs online localization.
 class OnlineLocalizer {
 public:

--- a/src/localization/online_localizer/path_element.h
+++ b/src/localization/online_localizer/path_element.h
@@ -1,4 +1,4 @@
-/** vpr_relocalization: a library for visual place recognition in changing 
+/** vpr_relocalization: a library for visual place recognition in changing
 ** environments with efficient relocalization step.
 ** Copyright (c) 2017 O. Vysotska, C. Stachniss, University of Bonn
 **
@@ -24,13 +24,18 @@
 #ifndef SRC_ONLINE_LOCALIZER_PATH_ELEMENT_H_
 #define SRC_ONLINE_LOCALIZER_PATH_ELEMENT_H_
 
+#include <string>
+#include <vector>
+
+namespace localization::online_localizer {
+
 enum NodeState { REAL, HIDDEN };
 
 /**
  * @brief     Container class representing an element of the resulting path
  */
 class PathElement {
- public:
+public:
   PathElement() {}
   PathElement(int quId, int refId, NodeState state) {
     this->quId = quId;
@@ -43,4 +48,9 @@ class PathElement {
   void print() const;
 };
 
-#endif  // SRC_ONLINE_LOCALIZER_PATH_ELEMENT_H_
+using Matches = std::vector<PathElement>;
+void storeMatchesAsProto(const Matches &matches,
+                         const std::string &protoFilename);
+}; // namespace localization::online_localizer
+
+#endif // SRC_ONLINE_LOCALIZER_PATH_ELEMENT_H_

--- a/src/test/online_localizer_test.cpp
+++ b/src/test/online_localizer_test.cpp
@@ -67,7 +67,7 @@ TEST_F(OnlineLocalizerTest, Get) {
   for (int i = 0; i < matches.size(); ++i) {
     EXPECT_EQ(matches[i].quId, matches.size() - 1 - i);
     EXPECT_EQ(matches[i].refId, matches.size() - 1 - i);
-    EXPECT_EQ(matches[i].state, NodeState::REAL);
+    EXPECT_EQ(matches[i].state, loc::online_localizer::NodeState::REAL);
   }
 }
 


### PR DESCRIPTION
This PR adds a binary for performing the feature retrieval based purely on Locality Sensitive Hashing without taking the sequences into account. The algorithm returns the 1 best candidate for now.
If there is no candidate found the result is the id 0 with the HIDDEN status.